### PR TITLE
fix: lib not working for projects with multiple info.plist

### DIFF
--- a/packages/react-native-nano-icons/__tests__/link.unit.test.ts
+++ b/packages/react-native-nano-icons/__tests__/link.unit.test.ts
@@ -59,9 +59,7 @@ describe('linkBare — iOS Info.plist target selection', () => {
     const iosDir = path.join(projectRoot, 'ios');
     fs.mkdirSync(iosDir);
 
-    // Decoy target — created first AND alphabetically first, so any
-    // readdir ordering (alphabetical or insertion-order) returns it
-    // before MyApp. The pre-fix code would have picked this one.
+    // decoy - alphabetically-first, should be ignored
     fs.mkdirSync(path.join(iosDir, 'AppExtension'));
     fs.writeFileSync(
       path.join(iosDir, 'AppExtension', 'Info.plist'),

--- a/packages/react-native-nano-icons/__tests__/link.unit.test.ts
+++ b/packages/react-native-nano-icons/__tests__/link.unit.test.ts
@@ -1,0 +1,111 @@
+/** @jest-environment node */
+
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import * as plist from 'plist';
+
+jest.mock('xcode', () => ({
+  project: () => ({
+    parseSync() {
+      return this;
+    },
+    getFirstTarget: () => ({ uuid: 'fake-target-uuid' }),
+    addBuildPhase: () => {},
+    writeSync: () => '// fake pbxproj',
+    hash: { project: { objects: {} } },
+  }),
+}));
+
+import { linkBare } from '../cli/link';
+import type { NanoLogger } from '../cli/logger';
+import type { BuiltFont } from '../cli/build';
+
+const MINIMAL_PLIST = plist.build({ CFBundleName: 'placeholder' });
+
+function makeTmpDir(): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'nano-link-'));
+}
+
+function makeLogger(): NanoLogger {
+  return {
+    start: jest.fn(),
+    update: jest.fn(),
+    succeed: jest.fn(),
+    fail: jest.fn(),
+    info: jest.fn(),
+    warn: jest.fn(),
+  };
+}
+
+function readUIAppFonts(plistPath: string): string[] {
+  const parsed = plist.parse(fs.readFileSync(plistPath, 'utf8')) as Record<
+    string,
+    unknown
+  >;
+  return Array.isArray(parsed['UIAppFonts'])
+    ? (parsed['UIAppFonts'] as string[])
+    : [];
+}
+
+describe('linkBare — iOS Info.plist target selection', () => {
+  let projectRoot: string;
+  let fontDir: string;
+
+  beforeEach(() => {
+    projectRoot = makeTmpDir();
+    fontDir = makeTmpDir();
+
+    const iosDir = path.join(projectRoot, 'ios');
+    fs.mkdirSync(iosDir);
+
+    // Decoy target — created first AND alphabetically first, so any
+    // readdir ordering (alphabetical or insertion-order) returns it
+    // before MyApp. The pre-fix code would have picked this one.
+    fs.mkdirSync(path.join(iosDir, 'AppExtension'));
+    fs.writeFileSync(
+      path.join(iosDir, 'AppExtension', 'Info.plist'),
+      MINIMAL_PLIST
+    );
+
+    // Main app target
+    fs.mkdirSync(path.join(iosDir, 'MyApp'));
+    fs.writeFileSync(path.join(iosDir, 'MyApp', 'Info.plist'), MINIMAL_PLIST);
+
+    // real target via Info.plist
+    fs.mkdirSync(path.join(iosDir, 'MyApp.xcodeproj'));
+    fs.writeFileSync(
+      path.join(iosDir, 'MyApp.xcodeproj', 'project.pbxproj'),
+      '// fake pbxproj'
+    );
+
+    fs.writeFileSync(path.join(fontDir, 'TestFont.ttf'), 'fake-ttf');
+  });
+
+  afterEach(() => {
+    fs.rmSync(projectRoot, { recursive: true, force: true });
+    fs.rmSync(fontDir, { recursive: true, force: true });
+  });
+
+  test('updates the main app Info.plist, not the alphabetically-first sibling', async () => {
+    const builtFont: BuiltFont = {
+      fontFamily: 'TestFont',
+      ttfPath: path.join(fontDir, 'TestFont.ttf'),
+      glyphmapPath: path.join(fontDir, 'TestFont.glyphmap.json'),
+    };
+
+    await linkBare(projectRoot, [builtFont], makeLogger());
+
+    const mainPlist = path.join(projectRoot, 'ios', 'MyApp', 'Info.plist');
+    const decoyPlist = path.join(
+      projectRoot,
+      'ios',
+      'AppExtension',
+      'Info.plist'
+    );
+
+    expect(readUIAppFonts(mainPlist)).toContain('TestFont.ttf');
+    expect(readUIAppFonts(decoyPlist)).not.toContain('TestFont.ttf');
+    expect(readUIAppFonts(decoyPlist)).toEqual([]);
+  });
+});

--- a/packages/react-native-nano-icons/cli/link.ts
+++ b/packages/react-native-nano-icons/cli/link.ts
@@ -13,7 +13,12 @@ type ShellScriptOptions = {
 
 type XcodeProject = {
   parseSync: () => XcodeProject;
-  getFirstTarget: () => { uuid: string };
+  getFirstTarget: () => { uuid: string; firstTarget: { name: string } };
+  getBuildProperty: (
+    prop: string,
+    build?: string,
+    targetName?: string
+  ) => string | undefined;
   addBuildPhase: (
     filePaths: string[],
     phaseType: string,
@@ -49,18 +54,44 @@ async function linkAndroid(
   }
 }
 
+function resolveInfoPlistPath(
+  project: XcodeProject,
+  targetName: string,
+  iosDir: string
+): string | null {
+  const raw = project.getBuildProperty('INFOPLIST_FILE', undefined, targetName);
+  if (!raw) return null;
+
+  const unquoted = raw.replace(/^"(.*)"$/, '$1');
+  const resolved = unquoted
+    .replace(/\$\(SRCROOT\)/g, iosDir)
+    .replace(/\$\{SRCROOT\}/g, iosDir);
+
+  return path.isAbsolute(resolved) ? resolved : path.join(iosDir, resolved);
+}
+
 async function linkIos(
   projectRoot: string,
   builtFonts: BuiltFont[]
 ): Promise<void> {
   const iosDir = path.join(projectRoot, 'ios');
 
-  const appDir = fs
+  const xcodeprojDir = fs
     .readdirSync(iosDir, { withFileTypes: true })
-    .filter((d) => d.isDirectory())
-    .find((d) => fs.existsSync(path.join(iosDir, d.name, 'Info.plist')));
+    .find((d) => d.name.endsWith('.xcodeproj'));
 
-  if (!appDir) return;
+  if (!xcodeprojDir) return;
+
+  const pbxprojPath = path.join(iosDir, xcodeprojDir.name, 'project.pbxproj');
+  const xcode = require('xcode') as { project: (p: string) => XcodeProject };
+  const project = xcode.project(pbxprojPath);
+  project.parseSync();
+
+  const firstTarget = project.getFirstTarget();
+  const targetName = firstTarget.firstTarget.name.replace(/^"|"$/g, '');
+
+  const infoPlistPath = resolveInfoPlistPath(project, targetName, iosDir);
+  if (!infoPlistPath || !fs.existsSync(infoPlistPath)) return;
 
   const fontNames: string[] = [];
   const iosFontsStaging = path.join(iosDir, IOS_NANOICONS_FONTS_DIR);
@@ -72,7 +103,6 @@ async function linkIos(
     fs.copyFileSync(b.ttfPath, path.join(iosFontsStaging, name));
   }
 
-  const infoPlistPath = path.join(iosDir, appDir.name, 'Info.plist');
   const plistContent = fs.readFileSync(infoPlistPath, 'utf8');
   const obj = plist.parse(plistContent) as plist.PlistObject;
 
@@ -87,41 +117,30 @@ async function linkIos(
   };
   fs.writeFileSync(infoPlistPath, plist.build(updated), 'utf8');
 
-  const xcodeprojDir = fs
-    .readdirSync(iosDir, { withFileTypes: true })
-    .find((d) => d.name.endsWith('.xcodeproj'));
+  const hasPhase = Object.entries(
+    project.hash.project.objects['PBXShellScriptBuildPhase'] ?? {}
+  ).some(
+    ([, v]) =>
+      typeof v === 'object' && v?.name?.includes(IOS_RUN_SCRIPT_PHASE_NAME)
+  );
 
-  if (xcodeprojDir) {
-    const pbxprojPath = path.join(iosDir, xcodeprojDir.name, 'project.pbxproj');
-    const xcode = require('xcode') as { project: (p: string) => XcodeProject };
-    const project = xcode.project(pbxprojPath);
-    project.parseSync();
-
-    const hasPhase = Object.entries(
-      project.hash.project.objects['PBXShellScriptBuildPhase'] ?? {}
-    ).some(
-      ([, v]) =>
-        typeof v === 'object' && v?.name?.includes(IOS_RUN_SCRIPT_PHASE_NAME)
-    );
-
-    if (!hasPhase) {
-      const script = `
+  if (!hasPhase) {
+    const script = `
         NANOICONS_DIR="\\\${PROJECT_DIR}/${IOS_NANOICONS_FONTS_DIR}"
         if [ -d "$NANOICONS_DIR" ]; then
           cp "$NANOICONS_DIR"/*.ttf "\\\${BUILT_PRODUCTS_DIR}/\\\${UNLOCALIZED_RESOURCES_FOLDER_PATH}/" 2>/dev/null || true
         fi
       `;
 
-      project.addBuildPhase(
-        [],
-        'PBXShellScriptBuildPhase',
-        IOS_RUN_SCRIPT_PHASE_NAME,
-        project.getFirstTarget().uuid,
-        { shellPath: '/bin/sh', shellScript: script }
-      );
+    project.addBuildPhase(
+      [],
+      'PBXShellScriptBuildPhase',
+      IOS_RUN_SCRIPT_PHASE_NAME,
+      firstTarget.uuid,
+      { shellPath: '/bin/sh', shellScript: script }
+    );
 
-      fs.writeFileSync(pbxprojPath, project.writeSync(), 'utf8');
-    }
+    fs.writeFileSync(pbxprojPath, project.writeSync(), 'utf8');
   }
 }
 

--- a/packages/react-native-nano-icons/cli/link.ts
+++ b/packages/react-native-nano-icons/cli/link.ts
@@ -13,12 +13,7 @@ type ShellScriptOptions = {
 
 type XcodeProject = {
   parseSync: () => XcodeProject;
-  getFirstTarget: () => { uuid: string; firstTarget: { name: string } };
-  getBuildProperty: (
-    prop: string,
-    build?: string,
-    targetName?: string
-  ) => string | undefined;
+  getFirstTarget: () => { uuid: string };
   addBuildPhase: (
     filePaths: string[],
     phaseType: string,
@@ -54,22 +49,6 @@ async function linkAndroid(
   }
 }
 
-function resolveInfoPlistPath(
-  project: XcodeProject,
-  targetName: string,
-  iosDir: string
-): string | null {
-  const raw = project.getBuildProperty('INFOPLIST_FILE', undefined, targetName);
-  if (!raw) return null;
-
-  const unquoted = raw.replace(/^"(.*)"$/, '$1');
-  const resolved = unquoted
-    .replace(/\$\(SRCROOT\)/g, iosDir)
-    .replace(/\$\{SRCROOT\}/g, iosDir);
-
-  return path.isAbsolute(resolved) ? resolved : path.join(iosDir, resolved);
-}
-
 async function linkIos(
   projectRoot: string,
   builtFonts: BuiltFont[]
@@ -82,16 +61,9 @@ async function linkIos(
 
   if (!xcodeprojDir) return;
 
-  const pbxprojPath = path.join(iosDir, xcodeprojDir.name, 'project.pbxproj');
-  const xcode = require('xcode') as { project: (p: string) => XcodeProject };
-  const project = xcode.project(pbxprojPath);
-  project.parseSync();
-
-  const firstTarget = project.getFirstTarget();
-  const targetName = firstTarget.firstTarget.name.replace(/^"|"$/g, '');
-
-  const infoPlistPath = resolveInfoPlistPath(project, targetName, iosDir);
-  if (!infoPlistPath || !fs.existsSync(infoPlistPath)) return;
+  const appName = xcodeprojDir.name.replace(/\.xcodeproj$/, '');
+  const infoPlistPath = path.join(iosDir, appName, 'Info.plist');
+  if (!fs.existsSync(infoPlistPath)) return;
 
   const fontNames: string[] = [];
   const iosFontsStaging = path.join(iosDir, IOS_NANOICONS_FONTS_DIR);
@@ -117,6 +89,11 @@ async function linkIos(
   };
   fs.writeFileSync(infoPlistPath, plist.build(updated), 'utf8');
 
+  const pbxprojPath = path.join(iosDir, xcodeprojDir.name, 'project.pbxproj');
+  const xcode = require('xcode') as { project: (p: string) => XcodeProject };
+  const project = xcode.project(pbxprojPath);
+  project.parseSync();
+
   const hasPhase = Object.entries(
     project.hash.project.objects['PBXShellScriptBuildPhase'] ?? {}
   ).some(
@@ -136,7 +113,7 @@ async function linkIos(
       [],
       'PBXShellScriptBuildPhase',
       IOS_RUN_SCRIPT_PHASE_NAME,
-      firstTarget.uuid,
+      project.getFirstTarget().uuid,
       { shellPath: '/bin/sh', shellScript: script }
     );
 


### PR DESCRIPTION
## Description

<!--
Description and motivation for this PR.

Include 'Fixes #<number>' if this is fixing some issue.
-->
The bug: code scanned ios/ and picked the first directory containing Info.plist -> alphabetical order, not always matching the actual app directory. 

This is the direct reason of the bug,
```
  const appDir = fs
    .readdirSync(iosDir, { withFileTypes: true })
    .filter((d) => d.isDirectory())
    .find((d) => fs.existsSync(path.join(iosDir, d.name, 'Info.plist')));
```
readdirSync returns in alphabetical order, then find returns only the first match.


## Solution
proposed solution is to never scan for Info.plist at all. Instead find the .xcodeproj file (there's only one per RN project) and construct the path directly from there.


## Test plan
Created a test that mocks this situation - places the correct info.plist as the non-first in alphabetical order
<!--
Describe how did you test this change here.
-->
