### PR TITLE
chore: reduce dependency footprint

### DIFF
--- a/LICENSES.md
+++ b/LICENSES.md
@@ -10,9 +10,9 @@ This project bundles or depends on the following third-party software:
    License: MIT
    Source: https://www.npmjs.com/package/fonteditor-core
 
-3. jsdom
+3. @xmldom/xmldom
    License: MIT
-   Source: https://github.com/jsdom/jsdom
+   Source: https://github.com/xmldom/xmldom
 
 4. minimist
    License: MIT

--- a/LICENSES.md
+++ b/LICENSES.md
@@ -18,19 +18,15 @@ This project bundles or depends on the following third-party software:
    License: MIT
    Source: https://github.com/minimistjs/minimist
 
-5. svgicons2svgfont
-   License: MIT
-   Source: https://github.com/nfroidure/svgicons2svgfont
-
-6. svg2ttf
+5. svg2ttf
    License: MIT
    Source: https://www.npmjs.com/package/svg2ttf
 
-7. pathkit-wasm
+6. pathkit-wasm
    License: BSD-3-Clause
    Source: https://www.npmjs.com/package/pathkit-wasm
 
-8. pyodide
+7. pyodide
    License: MPL-2.0
    Source: https://www.npmjs.com/package/pyodide
 

--- a/packages/react-native-nano-icons/LICENSES.md
+++ b/packages/react-native-nano-icons/LICENSES.md
@@ -10,9 +10,9 @@ This project bundles or depends on the following third-party software:
    License: MIT
    Source: https://www.npmjs.com/package/fonteditor-core
 
-3. jsdom
+3. @xmldom/xmldom
    License: MIT
-   Source: https://github.com/jsdom/jsdom
+   Source: https://github.com/xmldom/xmldom
 
 4. minimist
    License: MIT

--- a/packages/react-native-nano-icons/LICENSES.md
+++ b/packages/react-native-nano-icons/LICENSES.md
@@ -18,19 +18,15 @@ This project bundles or depends on the following third-party software:
    License: MIT
    Source: https://github.com/minimistjs/minimist
 
-5. svgicons2svgfont
-   License: MIT
-   Source: https://github.com/nfroidure/svgicons2svgfont
-
-6. svg2ttf
+5. svg2ttf
    License: MIT
    Source: https://www.npmjs.com/package/svg2ttf
 
-7. pathkit-wasm
+6. pathkit-wasm
    License: BSD-3-Clause
    Source: https://www.npmjs.com/package/pathkit-wasm
 
-8. pyodide
+7. pyodide
    License: MPL-2.0
    Source: https://www.npmjs.com/package/pyodide
 

--- a/packages/react-native-nano-icons/__tests__/svg_dom.unit.test.ts
+++ b/packages/react-native-nano-icons/__tests__/svg_dom.unit.test.ts
@@ -1,6 +1,6 @@
 /** @jest-environment node */
 
-import { JSDOM } from 'jsdom';
+import { DOMParser, type Element } from '@xmldom/xmldom';
 import {
   calculateOpColor,
   parseFlattenedSvg,
@@ -64,10 +64,10 @@ describe('parseColor', () => {
 // ---------------------------------------------------------------------------
 
 describe('calculateOpColor', () => {
-  function makeElement(svg: string, selector: string): Element {
-    const doc = new JSDOM(svg).window.document;
-    const el = doc.querySelector(selector);
-    if (!el) throw new Error(`No element matching "${selector}"`);
+  function makeElement(svg: string, tagName: string): Element {
+    const doc = new DOMParser().parseFromString(svg, 'image/svg+xml');
+    const el = doc.getElementsByTagName(tagName)[0];
+    if (!el) throw new Error(`No <${tagName}> element found`);
     return el;
   }
 

--- a/packages/react-native-nano-icons/docs/PIPELINE.md
+++ b/packages/react-native-nano-icons/docs/PIPELINE.md
@@ -349,7 +349,7 @@ Checks if `parent` is a `ReactTextView`. If so, reads the text layout paint's `f
 | `picosvg` | 0.22.3 | SVG flattening (bundled .whl) |
 | `svg2ttf` | ^6.0.3 | SVG font → TTF conversion |
 | `fonteditor-core` | ^2.6.3 | TTF metric correction |
-| `jsdom` | ^28.1.0 | DOM parsing in Node.js |
+| `@xmldom/xmldom` | ^0.9.10 | XML DOM parsing in Node.js |
 
 ---
 

--- a/packages/react-native-nano-icons/jest.config.js
+++ b/packages/react-native-nano-icons/jest.config.js
@@ -14,6 +14,6 @@ module.exports = {
     '^.+\\.(js|mjs|cjs|ts|tsx)$': 'babel-jest',
   },
   transformIgnorePatterns: [
-    'node_modules/(?!((jest-)?react-native|@react-native(-community)?|@exodus/bytes|@csstools|parse5|pyodide|svg-pathdata|yerror)/|jsdom/node_modules/)',
+    'node_modules/(?!((jest-)?react-native|@react-native(-community)?|@exodus/bytes|@csstools|parse5|pyodide|svg-pathdata|yerror)/)',
   ],
 };

--- a/packages/react-native-nano-icons/jest.config.js
+++ b/packages/react-native-nano-icons/jest.config.js
@@ -14,6 +14,6 @@ module.exports = {
     '^.+\\.(js|mjs|cjs|ts|tsx)$': 'babel-jest',
   },
   transformIgnorePatterns: [
-    'node_modules/(?!((jest-)?react-native|@react-native(-community)?|@exodus/bytes|@csstools|parse5|pyodide|svgicons2svgfont|svg-pathdata|yerror)/|jsdom/node_modules/)',
+    'node_modules/(?!((jest-)?react-native|@react-native(-community)?|@exodus/bytes|@csstools|parse5|pyodide|svg-pathdata|yerror)/|jsdom/node_modules/)',
   ],
 };

--- a/packages/react-native-nano-icons/package.json
+++ b/packages/react-native-nano-icons/package.json
@@ -37,9 +37,9 @@
   },
   "dependencies": {
     "@expo/config-plugins": ">=9.0.0",
+    "@xmldom/xmldom": "^0.9.10",
     "chalk": "^5.6.2",
     "fonteditor-core": "^2.6.3",
-    "jsdom": "^28.1.0",
     "ora": "^9.3.0",
     "pathkit-wasm": "^1.0.0",
     "plist": "^3.0.5",

--- a/packages/react-native-nano-icons/package.json
+++ b/packages/react-native-nano-icons/package.json
@@ -45,7 +45,6 @@
     "plist": "^3.0.5",
     "pyodide": "^0.29.3",
     "svg2ttf": "^6.0.3",
-    "svgicons2svgfont": "^15.0.1",
     "xcode": "^3.0.1"
   },
   "peerDependencies": {

--- a/packages/react-native-nano-icons/src/core/svg/svg_dom.ts
+++ b/packages/react-native-nano-icons/src/core/svg/svg_dom.ts
@@ -149,14 +149,18 @@ export function extractOriginalEvenoddDs(svgContent: string): string[] {
 
   const doc = new DOMParser().parseFromString(svgContent, 'image/svg+xml');
 
-  return Array.from(doc.getElementsByTagName('path'))
-    .filter(
-      (el) =>
+  return Array.from(doc.getElementsByTagName('path')).reduce<string[]>(
+    (acc, el) => {
+      const isEvenOdd =
         el.getAttribute('fill-rule') === 'evenodd' ||
-        el.getAttribute('clip-rule') === 'evenodd'
-    )
-    .map((el) => el.getAttribute('d'))
-    .filter((d): d is string => d !== null && d !== '');
+        el.getAttribute('clip-rule') === 'evenodd';
+      if (!isEvenOdd) return acc;
+      const d = el.getAttribute('d');
+      if (d !== null && d !== '') acc.push(d);
+      return acc;
+    },
+    []
+  );
 }
 
 /**

--- a/packages/react-native-nano-icons/src/core/svg/svg_dom.ts
+++ b/packages/react-native-nano-icons/src/core/svg/svg_dom.ts
@@ -107,28 +107,18 @@ export function parseFlattenedSvg(
     .map(Number) ?? [0, 0, 100, 100];
 
   const viewBox: [number, number, number, number] =
-    viewBoxRaw.length === 4 &&
-    viewBoxRaw.every((n: number) => Number.isFinite(n))
+    viewBoxRaw.length === 4 && viewBoxRaw.every(Number.isFinite)
       ? [viewBoxRaw[0]!, viewBoxRaw[1]!, viewBoxRaw[2]!, viewBoxRaw[3]!]
       : [0, 0, 100, 100];
 
-  const pathNodes = svgEl ? svgEl.getElementsByTagName('path') : null;
-  const pathEls: Element[] = [];
-  if (pathNodes) {
-    for (let i = 0; i < pathNodes.length; i++) {
-      const el = pathNodes[i];
-      if (el) pathEls.push(el);
-    }
-  }
+  const pathEls = svgEl ? Array.from(svgEl.getElementsByTagName('path')) : [];
 
   const paths = pathEls
     .map(parsePath)
     .filter((p) => p.d.trim() !== '')
     .map((p) => {
       const { d, sanitized } = sanitizePathData(p.d);
-      if (sanitized) {
-        options?.onSanitize?.(p.d);
-      }
+      if (sanitized) options?.onSanitize?.(p.d);
       return { ...p, d };
     });
 
@@ -167,21 +157,15 @@ export function extractOriginalEvenoddDs(svgContent: string): string[] {
   }
 
   const doc = new DOMParser().parseFromString(svgContent, 'image/svg+xml');
-  const results: string[] = [];
 
-  const pathNodes = doc.getElementsByTagName('path');
-  for (let i = 0; i < pathNodes.length; i++) {
-    const el = pathNodes[i];
-    if (!el) continue;
-    if (
-      el.getAttribute('fill-rule') === 'evenodd' ||
-      el.getAttribute('clip-rule') === 'evenodd'
-    ) {
-      const d = el.getAttribute('d');
-      if (d) results.push(d);
-    }
-  }
-  return results;
+  return Array.from(doc.getElementsByTagName('path'))
+    .filter(
+      (el) =>
+        el.getAttribute('fill-rule') === 'evenodd' ||
+        el.getAttribute('clip-rule') === 'evenodd'
+    )
+    .map((el) => el.getAttribute('d'))
+    .filter((d): d is string => d !== null && d !== '');
 }
 
 /**

--- a/packages/react-native-nano-icons/src/core/svg/svg_dom.ts
+++ b/packages/react-native-nano-icons/src/core/svg/svg_dom.ts
@@ -1,4 +1,4 @@
-import { JSDOM } from 'jsdom';
+import { DOMParser, type Element, type Node } from '@xmldom/xmldom';
 import { parseColor } from '../../utils/parse';
 
 export type ParsedFlatSvg = {
@@ -6,13 +6,22 @@ export type ParsedFlatSvg = {
   paths: Array<{ d: string; fill: string | null; fillRule?: 'evenodd' }>;
 };
 
+const ELEMENT_NODE = 1;
+
+function parentElementOf(node: Node): Element | null {
+  const parent = node.parentNode;
+  return parent && parent.nodeType === ELEMENT_NODE
+    ? (parent as Element)
+    : null;
+}
+
 // if the fill is implicit, walk ancestors for the first explicit fill value
 function resolveInheritedFill(el: Element): string {
-  let current: Element | null = el.parentElement;
+  let current: Element | null = parentElementOf(el);
   while (current !== null) {
     const fill = current.getAttribute('fill');
     if (fill !== null && fill !== 'inherit') return fill;
-    current = current.parentElement;
+    current = parentElementOf(current);
   }
   return 'black';
 }
@@ -89,21 +98,28 @@ export function parseFlattenedSvg(
   flattenedSvg: string,
   options?: { onSanitize?: (original: string) => void }
 ): ParsedFlatSvg {
-  const dom = new JSDOM(flattenedSvg);
-  const doc = dom.window.document;
+  const doc = new DOMParser().parseFromString(flattenedSvg, 'image/svg+xml');
+  const svgEl = doc.documentElement;
 
-  const svgEl = doc.querySelector('svg');
   const viewBoxRaw = svgEl
     ?.getAttribute('viewBox')
     ?.split(/\s+/)
     .map(Number) ?? [0, 0, 100, 100];
 
   const viewBox: [number, number, number, number] =
-    viewBoxRaw.length === 4 && viewBoxRaw.every((n) => Number.isFinite(n))
+    viewBoxRaw.length === 4 &&
+    viewBoxRaw.every((n: number) => Number.isFinite(n))
       ? [viewBoxRaw[0]!, viewBoxRaw[1]!, viewBoxRaw[2]!, viewBoxRaw[3]!]
       : [0, 0, 100, 100];
 
-  const pathEls = Array.from(doc.querySelectorAll('path'));
+  const pathNodes = svgEl ? svgEl.getElementsByTagName('path') : null;
+  const pathEls: Element[] = [];
+  if (pathNodes) {
+    for (let i = 0; i < pathNodes.length; i++) {
+      const el = pathNodes[i];
+      if (el) pathEls.push(el);
+    }
+  }
 
   const paths = pathEls
     .map(parsePath)
@@ -150,16 +166,20 @@ export function extractOriginalEvenoddDs(svgContent: string): string[] {
     return [];
   }
 
-  const dom = new JSDOM(svgContent, { contentType: 'image/svg+xml' });
-  const doc = dom.window.document;
+  const doc = new DOMParser().parseFromString(svgContent, 'image/svg+xml');
   const results: string[] = [];
 
-  const pathEls = doc.querySelectorAll(
-    'path[fill-rule="evenodd"], path[clip-rule="evenodd"]'
-  );
-  for (const el of pathEls) {
-    const d = el.getAttribute('d');
-    if (d) results.push(d);
+  const pathNodes = doc.getElementsByTagName('path');
+  for (let i = 0; i < pathNodes.length; i++) {
+    const el = pathNodes[i];
+    if (!el) continue;
+    if (
+      el.getAttribute('fill-rule') === 'evenodd' ||
+      el.getAttribute('clip-rule') === 'evenodd'
+    ) {
+      const d = el.getAttribute('d');
+      if (d) results.push(d);
+    }
   }
   return results;
 }
@@ -187,5 +207,3 @@ export function preprocessSvg(content: string): string {
   if (/xmlns\s*=/.test(content)) return content;
   return content.replace(/<svg\b/, '<svg xmlns="http://www.w3.org/2000/svg"');
 }
-
-

--- a/packages/react-native-nano-icons/src/core/svg/svg_dom.ts
+++ b/packages/react-native-nano-icons/src/core/svg/svg_dom.ts
@@ -1,4 +1,4 @@
-import { DOMParser, type Element, type Node } from '@xmldom/xmldom';
+import { DOMParser, type Element } from '@xmldom/xmldom';
 import { parseColor } from '../../utils/parse';
 
 export type ParsedFlatSvg = {
@@ -6,22 +6,13 @@ export type ParsedFlatSvg = {
   paths: Array<{ d: string; fill: string | null; fillRule?: 'evenodd' }>;
 };
 
-const ELEMENT_NODE = 1;
-
-function parentElementOf(node: Node): Element | null {
-  const parent = node.parentNode;
-  return parent && parent.nodeType === ELEMENT_NODE
-    ? (parent as Element)
-    : null;
-}
-
 // if the fill is implicit, walk ancestors for the first explicit fill value
 function resolveInheritedFill(el: Element): string {
-  let current: Element | null = parentElementOf(el);
+  let current = el.parentElement;
   while (current !== null) {
     const fill = current.getAttribute('fill');
     if (fill !== null && fill !== 'inherit') return fill;
-    current = parentElementOf(current);
+    current = current.parentElement;
   }
   return 'black';
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -17,13 +17,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@acemir/cssom@npm:^0.9.31":
-  version: 0.9.31
-  resolution: "@acemir/cssom@npm:0.9.31"
-  checksum: 10c0/cbfff98812642104ec3b37de1ad3a53f216ddc437e7b9276a23f46f2453844ea3c3f46c200bc4656a2f747fb26567560b3cc5183d549d119a758926551b5f566
-  languageName: node
-  linkType: hard
-
 "@ark/schema@npm:0.56.0":
   version: 0.56.0
   resolution: "@ark/schema@npm:0.56.0"
@@ -37,39 +30,6 @@ __metadata:
   version: 0.56.0
   resolution: "@ark/util@npm:0.56.0"
   checksum: 10c0/dfef779c90f9f814ba97069c63bf91fa67569b87c5cd925d0e2d96b91aa677c019ed1dd5ff95332d9bb0598f785057439074b8cbfcaa2578770616e260fc5761
-  languageName: node
-  linkType: hard
-
-"@asamuzakjp/css-color@npm:^4.1.2":
-  version: 4.1.2
-  resolution: "@asamuzakjp/css-color@npm:4.1.2"
-  dependencies:
-    "@csstools/css-calc": "npm:^3.0.0"
-    "@csstools/css-color-parser": "npm:^4.0.1"
-    "@csstools/css-parser-algorithms": "npm:^4.0.0"
-    "@csstools/css-tokenizer": "npm:^4.0.0"
-    lru-cache: "npm:^11.2.5"
-  checksum: 10c0/e432fdef978b37654a2ca31169a149b9173e708f70c82612acb123a36dbc7dd99913c48cbf2edd6fe3652cc627d4bc94bf87571463da0b788f15b973d4ce5b0f
-  languageName: node
-  linkType: hard
-
-"@asamuzakjp/dom-selector@npm:^6.8.1":
-  version: 6.8.1
-  resolution: "@asamuzakjp/dom-selector@npm:6.8.1"
-  dependencies:
-    "@asamuzakjp/nwsapi": "npm:^2.3.9"
-    bidi-js: "npm:^1.0.3"
-    css-tree: "npm:^3.1.0"
-    is-potential-custom-element-name: "npm:^1.0.1"
-    lru-cache: "npm:^11.2.6"
-  checksum: 10c0/635de2c3b11971c07e2d491fd2833d2499bafbab05b616f5d38041031718879c404456644f60c45e9ba4ca2423e5bb48bf3c46179b0c58a0ea68eaae8c61e85f
-  languageName: node
-  linkType: hard
-
-"@asamuzakjp/nwsapi@npm:^2.3.9":
-  version: 2.3.9
-  resolution: "@asamuzakjp/nwsapi@npm:2.3.9"
-  checksum: 10c0/869b81382e775499c96c45c6dbe0d0766a6da04bcf0abb79f5333535c4e19946851acaa43398f896e2ecc5a1de9cf3db7cf8c4b1afac1ee3d15e21584546d74d
   languageName: node
   linkType: hard
 
@@ -1654,17 +1614,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@bramus/specificity@npm:^2.4.2":
-  version: 2.4.2
-  resolution: "@bramus/specificity@npm:2.4.2"
-  dependencies:
-    css-tree: "npm:^3.0.0"
-  bin:
-    specificity: bin/cli.js
-  checksum: 10c0/c5f4e04e0bca0d2202598207a5eb0733c8109d12a68a329caa26373bec598d99db5bb785b8865fefa00fc01b08c6068138807ceb11a948fe15e904ed6cf4ba72
-  languageName: node
-  linkType: hard
-
 "@commitlint/cli@npm:^19.8.1":
   version: 19.8.1
   resolution: "@commitlint/cli@npm:19.8.1"
@@ -1853,59 +1802,6 @@ __metadata:
     "@types/conventional-commits-parser": "npm:^5.0.0"
     chalk: "npm:^5.3.0"
   checksum: 10c0/0507db111d1ffd7b60e7ad979b7f9e674d409fc4c64561dfe30737b2c5bfefca7a1b58116106fa4ecb480059cecb13f04fa18f999d2d4a7d665b5ab13a05a803
-  languageName: node
-  linkType: hard
-
-"@csstools/color-helpers@npm:^6.0.1":
-  version: 6.0.1
-  resolution: "@csstools/color-helpers@npm:6.0.1"
-  checksum: 10c0/866844267d5aa5a02fe9d54f6db6fc18f6306595edb03664cc8ef15c99d3e6f3b42eb1a413c98bafa5b2dc0d8e0193da9b3bcc9d6a04f5de74cbd44935e74b3c
-  languageName: node
-  linkType: hard
-
-"@csstools/css-calc@npm:^3.0.0":
-  version: 3.1.1
-  resolution: "@csstools/css-calc@npm:3.1.1"
-  peerDependencies:
-    "@csstools/css-parser-algorithms": ^4.0.0
-    "@csstools/css-tokenizer": ^4.0.0
-  checksum: 10c0/6efcc016d988edf66e54c7bad03e352d61752cbd1b56c7557fd013868aab23505052ded8f912cd4034e216943ea1e04c957d81012489e3eddc14a57b386510ef
-  languageName: node
-  linkType: hard
-
-"@csstools/css-color-parser@npm:^4.0.1":
-  version: 4.0.1
-  resolution: "@csstools/css-color-parser@npm:4.0.1"
-  dependencies:
-    "@csstools/color-helpers": "npm:^6.0.1"
-    "@csstools/css-calc": "npm:^3.0.0"
-  peerDependencies:
-    "@csstools/css-parser-algorithms": ^4.0.0
-    "@csstools/css-tokenizer": ^4.0.0
-  checksum: 10c0/c46be5b9f5c0ef3cd25b47a71bd2a4d1c4856b123ecba4abe8eaa0688d3fc47f58fa67ea281d6b9efca4b9fdfa88fb045c51d0f9b8c612a56bd546d38260b138
-  languageName: node
-  linkType: hard
-
-"@csstools/css-parser-algorithms@npm:^4.0.0":
-  version: 4.0.0
-  resolution: "@csstools/css-parser-algorithms@npm:4.0.0"
-  peerDependencies:
-    "@csstools/css-tokenizer": ^4.0.0
-  checksum: 10c0/94558c2428d6ef0ddef542e86e0a8376aa1263a12a59770abb13ba50d7b83086822c75433f32aa2e7fef00555e1cc88292f9ca5bce79aed232bb3fed73b1528d
-  languageName: node
-  linkType: hard
-
-"@csstools/css-syntax-patches-for-csstree@npm:^1.0.26":
-  version: 1.0.27
-  resolution: "@csstools/css-syntax-patches-for-csstree@npm:1.0.27"
-  checksum: 10c0/ef3f2a639109758c0f3c04520465800ca4c830174bd6f7979795083877c82ace51ab8353857b06a818cb6c0de6d4dc88f84a86fc3b021be47f11a0f1c4b74e7e
-  languageName: node
-  linkType: hard
-
-"@csstools/css-tokenizer@npm:^4.0.0":
-  version: 4.0.0
-  resolution: "@csstools/css-tokenizer@npm:4.0.0"
-  checksum: 10c0/669cf3d0f9c8e1ffdf8c9955ad8beba0c8cfe03197fe29a4fcbd9ee6f7a18856cfa42c62670021a75183d9ab37f5d14a866e6a9df753a6c07f59e36797a9ea9f
   languageName: node
   linkType: hard
 
@@ -2190,18 +2086,6 @@ __metadata:
     "@eslint/core": "npm:^1.1.0"
     levn: "npm:^0.4.1"
   checksum: 10c0/1d726338a9f4537fe2848796c44d801093ea3a99166dbc45bc6f7742fa2ad74ce0c2f114092ce4460710a9dfe5ea6e3500446f81842388bf81328c97c3a43d9d
-  languageName: node
-  linkType: hard
-
-"@exodus/bytes@npm:^1.11.0, @exodus/bytes@npm:^1.6.0":
-  version: 1.14.1
-  resolution: "@exodus/bytes@npm:1.14.1"
-  peerDependencies:
-    "@noble/hashes": ^1.8.0 || ^2.0.0
-  peerDependenciesMeta:
-    "@noble/hashes":
-      optional: true
-  checksum: 10c0/486dad30992a8c81058b6b59341ee934c10a7e8016b440770de0f86d2e270950c5d37fc6724ea017295b8654c7564abf6a21cc49bed569d74721b545f571e416
   languageName: node
   linkType: hard
 
@@ -6408,6 +6292,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@xmldom/xmldom@npm:^0.9.10":
+  version: 0.9.10
+  resolution: "@xmldom/xmldom@npm:0.9.10"
+  checksum: 10c0/38a9c9b95450d7fccebc61371c8e0b90ceaae992886484108333d29ccbd2640e3555b6af012f15ce1beb5067aeb40486659b6183fad38af179e82d28028bfc5d
+  languageName: node
+  linkType: hard
+
 "@yarnpkg/lockfile@npm:^1.1.0":
   version: 1.1.0
   resolution: "@yarnpkg/lockfile@npm:1.1.0"
@@ -7329,15 +7220,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"bidi-js@npm:^1.0.3":
-  version: 1.0.3
-  resolution: "bidi-js@npm:1.0.3"
-  dependencies:
-    require-from-string: "npm:^2.0.2"
-  checksum: 10c0/fdddea4aa4120a34285486f2267526cd9298b6e8b773ad25e765d4f104b6d7437ab4ba542e6939e3ac834a7570bcf121ee2cf6d3ae7cd7082c4b5bedc8f271e1
-  languageName: node
-  linkType: hard
-
 "big-integer@npm:1.6.x":
   version: 1.6.52
   resolution: "big-integer@npm:1.6.52"
@@ -8237,16 +8119,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"css-tree@npm:^3.0.0, css-tree@npm:^3.1.0":
-  version: 3.1.0
-  resolution: "css-tree@npm:3.1.0"
-  dependencies:
-    mdn-data: "npm:2.12.2"
-    source-map-js: "npm:^1.0.1"
-  checksum: 10c0/b5715852c2f397c715ca00d56ec53fc83ea596295ae112eb1ba6a1bda3b31086380e596b1d8c4b980fe6da09e7d0fc99c64d5bb7313030dd0fba9c1415f30979
-  languageName: node
-  linkType: hard
-
 "css-tree@npm:~2.2.0":
   version: 2.2.1
   resolution: "css-tree@npm:2.2.1"
@@ -8296,18 +8168,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"cssstyle@npm:^6.0.1":
-  version: 6.0.1
-  resolution: "cssstyle@npm:6.0.1"
-  dependencies:
-    "@asamuzakjp/css-color": "npm:^4.1.2"
-    "@csstools/css-syntax-patches-for-csstree": "npm:^1.0.26"
-    css-tree: "npm:^3.1.0"
-    lru-cache: "npm:^11.2.5"
-  checksum: 10c0/92a8581bad4ce9f77d22761f1aabe72829f4457ac709f4fe1a5b45b431ba165368cd7f849b00454ee31cf0a4c838be583107883f14b6d546802cf3c76a88ca41
-  languageName: node
-  linkType: hard
-
 "csstype@npm:^3.0.2, csstype@npm:^3.2.2":
   version: 3.2.3
   resolution: "csstype@npm:3.2.3"
@@ -8337,16 +8197,6 @@ __metadata:
     whatwg-mimetype: "npm:^3.0.0"
     whatwg-url: "npm:^11.0.0"
   checksum: 10c0/051c3aaaf3e961904f136aab095fcf6dff4db23a7fc759dd8ba7b3e6ba03fc07ef608086caad8ab910d864bd3b5e57d0d2f544725653d77c96a2c971567045f4
-  languageName: node
-  linkType: hard
-
-"data-urls@npm:^7.0.0":
-  version: 7.0.0
-  resolution: "data-urls@npm:7.0.0"
-  dependencies:
-    whatwg-mimetype: "npm:^5.0.0"
-    whatwg-url: "npm:^16.0.0"
-  checksum: 10c0/08d88ef50d8966a070ffdaa703e1e4b29f01bb2da364dfbc1612b1c2a4caa8045802c9532d81347b21781100132addb36a585071c8323b12cce97973961dee9f
   languageName: node
   linkType: hard
 
@@ -8427,7 +8277,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"decimal.js@npm:^10.4.2, decimal.js@npm:^10.6.0":
+"decimal.js@npm:^10.4.2":
   version: 10.6.0
   resolution: "decimal.js@npm:10.6.0"
   checksum: 10c0/07d69fbcc54167a340d2d97de95f546f9ff1f69d2b45a02fd7a5292412df3cd9eb7e23065e532a318f5474a2e1bccf8392fdf0443ef467f97f3bf8cb0477e5aa
@@ -11477,15 +11327,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"html-encoding-sniffer@npm:^6.0.0":
-  version: 6.0.0
-  resolution: "html-encoding-sniffer@npm:6.0.0"
-  dependencies:
-    "@exodus/bytes": "npm:^1.6.0"
-  checksum: 10c0/66dc3f6f5539cc3beb814fcbfae7eacf4ec38cf824d6e1425b72039b51a40f4456bd8541ba66f4f4fe09cdf885ab5cd5bae6ec6339d6895a930b2fdb83c53025
-  languageName: node
-  linkType: hard
-
 "html-escaper@npm:^2.0.0":
   version: 2.0.2
   resolution: "html-escaper@npm:2.0.2"
@@ -11524,7 +11365,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"http-proxy-agent@npm:^7.0.0, http-proxy-agent@npm:^7.0.2":
+"http-proxy-agent@npm:^7.0.0":
   version: 7.0.2
   resolution: "http-proxy-agent@npm:7.0.2"
   dependencies:
@@ -11544,7 +11385,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"https-proxy-agent@npm:^7.0.1, https-proxy-agent@npm:^7.0.5, https-proxy-agent@npm:^7.0.6":
+"https-proxy-agent@npm:^7.0.1, https-proxy-agent@npm:^7.0.5":
   version: 7.0.6
   resolution: "https-proxy-agent@npm:7.0.6"
   dependencies:
@@ -13425,40 +13266,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"jsdom@npm:^28.1.0":
-  version: 28.1.0
-  resolution: "jsdom@npm:28.1.0"
-  dependencies:
-    "@acemir/cssom": "npm:^0.9.31"
-    "@asamuzakjp/dom-selector": "npm:^6.8.1"
-    "@bramus/specificity": "npm:^2.4.2"
-    "@exodus/bytes": "npm:^1.11.0"
-    cssstyle: "npm:^6.0.1"
-    data-urls: "npm:^7.0.0"
-    decimal.js: "npm:^10.6.0"
-    html-encoding-sniffer: "npm:^6.0.0"
-    http-proxy-agent: "npm:^7.0.2"
-    https-proxy-agent: "npm:^7.0.6"
-    is-potential-custom-element-name: "npm:^1.0.1"
-    parse5: "npm:^8.0.0"
-    saxes: "npm:^6.0.0"
-    symbol-tree: "npm:^3.2.4"
-    tough-cookie: "npm:^6.0.0"
-    undici: "npm:^7.21.0"
-    w3c-xmlserializer: "npm:^5.0.0"
-    webidl-conversions: "npm:^8.0.1"
-    whatwg-mimetype: "npm:^5.0.0"
-    whatwg-url: "npm:^16.0.0"
-    xml-name-validator: "npm:^5.0.0"
-  peerDependencies:
-    canvas: ^3.0.0
-  peerDependenciesMeta:
-    canvas:
-      optional: true
-  checksum: 10c0/341ecb4005be2dab3247dacc349a20285d7991b5cee3382301fcd69a4294b705b4147e7d9ae1ddfab466ba4b3aace97ded4f7b070de285262221cb2782965b25
-  languageName: node
-  linkType: hard
-
 "jsesc@npm:^3.0.2, jsesc@npm:~3.1.0":
   version: 3.1.0
   resolution: "jsesc@npm:3.1.0"
@@ -14041,7 +13848,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"lru-cache@npm:^11.0.0, lru-cache@npm:^11.1.0, lru-cache@npm:^11.2.1, lru-cache@npm:^11.2.5, lru-cache@npm:^11.2.6":
+"lru-cache@npm:^11.0.0, lru-cache@npm:^11.1.0, lru-cache@npm:^11.2.1":
   version: 11.2.6
   resolution: "lru-cache@npm:11.2.6"
   checksum: 10c0/73bbffb298760e71b2bfe8ebc16a311c6a60ceddbba919cfedfd8635c2d125fbfb5a39b71818200e67973b11f8d59c5a9e31d6f90722e340e90393663a66e5cd
@@ -14143,13 +13950,6 @@ __metadata:
   version: 2.0.30
   resolution: "mdn-data@npm:2.0.30"
   checksum: 10c0/a2c472ea16cee3911ae742593715aa4c634eb3d4b9f1e6ada0902aa90df13dcbb7285d19435f3ff213ebaa3b2e0c0265c1eb0e3fb278fda7f8919f046a410cd9
-  languageName: node
-  linkType: hard
-
-"mdn-data@npm:2.12.2":
-  version: 2.12.2
-  resolution: "mdn-data@npm:2.12.2"
-  checksum: 10c0/b22443b71d70f72ccc3c6ba1608035431a8fc18c3c8fc53523f06d20e05c2ac10f9b53092759a2ca85cf02f0d37036f310b581ce03e7b99ac74d388ef8152ade
   languageName: node
   linkType: hard
 
@@ -15342,15 +15142,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"parse5@npm:^8.0.0":
-  version: 8.0.0
-  resolution: "parse5@npm:8.0.0"
-  dependencies:
-    entities: "npm:^6.0.0"
-  checksum: 10c0/8279892dcd77b2f2229707f60eb039e303adf0288812b2a8fd5acf506a4d432da833c6c5d07a6554bef722c2367a81ef4a1f7e9336564379a7dba3e798bf16b3
-  languageName: node
-  linkType: hard
-
 "parseurl@npm:~1.3.3":
   version: 1.3.3
   resolution: "parseurl@npm:1.3.3"
@@ -15993,13 +15784,13 @@ __metadata:
     "@types/plist": "npm:^3.0.5"
     "@types/react": "npm:~19.1.0"
     "@types/svg2ttf": "npm:^5.0.3"
+    "@xmldom/xmldom": "npm:^0.9.10"
     babel-plugin-module-resolver: "npm:^5.0.2"
     chalk: "npm:^5.6.2"
     del-cli: "npm:^6.0.0"
     expo-module-scripts: "npm:^5.0.8"
     fonteditor-core: "npm:^2.6.3"
     jest: "npm:^29.7.0"
-    jsdom: "npm:^28.1.0"
     ora: "npm:^9.3.0"
     patch-package: "npm:^8.0.0"
     pathkit-wasm: "npm:^1.0.0"
@@ -17998,24 +17789,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"tldts-core@npm:^7.0.23":
-  version: 7.0.23
-  resolution: "tldts-core@npm:7.0.23"
-  checksum: 10c0/b3d936a75b5f65614c356a58ef37563681c6224187dcce9f57aac76d92aae83b1a6fe6ab910f77472b35456bc145a8441cb3e572b4850be43cb4f3465e0610ec
-  languageName: node
-  linkType: hard
-
-"tldts@npm:^7.0.5":
-  version: 7.0.23
-  resolution: "tldts@npm:7.0.23"
-  dependencies:
-    tldts-core: "npm:^7.0.23"
-  bin:
-    tldts: bin/cli.js
-  checksum: 10c0/492874770afaade724a10f8a97cce511d74bed07735c7f1100b7957254d7a5bbbc18becaf5cd049f9d7b0feeb945a64af64d5a300dfb851a4ac57cf3a5998afc
-  languageName: node
-  linkType: hard
-
 "tmp@npm:^0.2.4":
   version: 0.2.5
   resolution: "tmp@npm:0.2.5"
@@ -18065,30 +17838,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"tough-cookie@npm:^6.0.0":
-  version: 6.0.0
-  resolution: "tough-cookie@npm:6.0.0"
-  dependencies:
-    tldts: "npm:^7.0.5"
-  checksum: 10c0/7b17a461e9c2ac0d0bea13ab57b93b4346d0b8c00db174c963af1e46e4ea8d04148d2a55f2358fc857db0c0c65208a98e319d0c60693e32e0c559a9d9cf20cb5
-  languageName: node
-  linkType: hard
-
 "tr46@npm:^3.0.0":
   version: 3.0.0
   resolution: "tr46@npm:3.0.0"
   dependencies:
     punycode: "npm:^2.1.1"
   checksum: 10c0/cdc47cad3a9d0b6cb293e39ccb1066695ae6fdd39b9e4f351b010835a1f8b4f3a6dc3a55e896b421371187f22b48d7dac1b693de4f6551bdef7b6ab6735dfe3b
-  languageName: node
-  linkType: hard
-
-"tr46@npm:^6.0.0":
-  version: 6.0.0
-  resolution: "tr46@npm:6.0.0"
-  dependencies:
-    punycode: "npm:^2.3.1"
-  checksum: 10c0/83130df2f649228aa91c17754b66248030a3af34911d713b5ea417066fa338aa4bc8668d06bd98aa21a2210f43fc0a3db8b9099e7747fb5830e40e39a6a1058e
   languageName: node
   linkType: hard
 
@@ -18377,13 +18132,6 @@ __metadata:
   version: 6.23.0
   resolution: "undici@npm:6.23.0"
   checksum: 10c0/d846b3fdfd05aa6081ba1eab5db6bbc21b283042c7a43722b86d1ee2bf749d7c990ceac0c809f9a07ffd88b1b0f4c0f548a8362c035088cb1997d63abdda499c
-  languageName: node
-  linkType: hard
-
-"undici@npm:^7.21.0":
-  version: 7.22.0
-  resolution: "undici@npm:7.22.0"
-  checksum: 10c0/09777c06f3f18f761f03e3a4c9c04fd9fcca8ad02ccea43602ee4adf73fcba082806f1afb637f6ea714ef6279c5323c25b16d435814c63db720f63bfc20d316b
   languageName: node
   linkType: hard
 
@@ -18703,15 +18451,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"w3c-xmlserializer@npm:^5.0.0":
-  version: 5.0.0
-  resolution: "w3c-xmlserializer@npm:5.0.0"
-  dependencies:
-    xml-name-validator: "npm:^5.0.0"
-  checksum: 10c0/8712774c1aeb62dec22928bf1cdfd11426c2c9383a1a63f2bcae18db87ca574165a0fbe96b312b73652149167ac6c7f4cf5409f2eb101d9c805efe0e4bae798b
-  languageName: node
-  linkType: hard
-
 "walker@npm:^1.0.7, walker@npm:^1.0.8":
   version: 1.0.8
   resolution: "walker@npm:1.0.8"
@@ -18758,13 +18497,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"webidl-conversions@npm:^8.0.1":
-  version: 8.0.1
-  resolution: "webidl-conversions@npm:8.0.1"
-  checksum: 10c0/3f6f327ca5fa0c065ed8ed0ef3b72f33623376e68f958e9b7bd0df49fdb0b908139ac2338d19fb45bd0e05595bda96cb6d1622222a8b413daa38a17aacc4dd46
-  languageName: node
-  linkType: hard
-
 "whatwg-encoding@npm:^2.0.0":
   version: 2.0.0
   resolution: "whatwg-encoding@npm:2.0.0"
@@ -18785,13 +18517,6 @@ __metadata:
   version: 3.0.0
   resolution: "whatwg-mimetype@npm:3.0.0"
   checksum: 10c0/323895a1cda29a5fb0b9ca82831d2c316309fede0365047c4c323073e3239067a304a09a1f4b123b9532641ab604203f33a1403b5ca6a62ef405bcd7a204080f
-  languageName: node
-  linkType: hard
-
-"whatwg-mimetype@npm:^5.0.0":
-  version: 5.0.0
-  resolution: "whatwg-mimetype@npm:5.0.0"
-  checksum: 10c0/eead164fe73a00dd82f817af6fc0bd22e9c273e1d55bf4bc6bdf2da7ad8127fca82ef00ea6a37892f5f5641f8e34128e09508f92126086baba126b9e0d57feb4
   languageName: node
   linkType: hard
 
@@ -18820,17 +18545,6 @@ __metadata:
     tr46: "npm:^3.0.0"
     webidl-conversions: "npm:^7.0.0"
   checksum: 10c0/f7ec264976d7c725e0696fcaf9ebe056e14422eacbf92fdbb4462034609cba7d0c85ffa1aab05e9309d42969bcf04632ba5ed3f3882c516d7b093053315bf4c1
-  languageName: node
-  linkType: hard
-
-"whatwg-url@npm:^16.0.0":
-  version: 16.0.0
-  resolution: "whatwg-url@npm:16.0.0"
-  dependencies:
-    "@exodus/bytes": "npm:^1.11.0"
-    tr46: "npm:^6.0.0"
-    webidl-conversions: "npm:^8.0.1"
-  checksum: 10c0/9b8cb392be244d0e9687ffe543f9ea63b7aa051a98547ea362a38d182d89bfbd96e13e7ed3f40df1f7566bb7c3581f6c081ddea950cf5382532716ce33000ff4
   languageName: node
   linkType: hard
 
@@ -19062,13 +18776,6 @@ __metadata:
   version: 4.0.0
   resolution: "xml-name-validator@npm:4.0.0"
   checksum: 10c0/c1bfa219d64e56fee265b2bd31b2fcecefc063ee802da1e73bad1f21d7afd89b943c9e2c97af2942f60b1ad46f915a4c81e00039c7d398b53cf410e29d3c30bd
-  languageName: node
-  linkType: hard
-
-"xml-name-validator@npm:^5.0.0":
-  version: 5.0.0
-  resolution: "xml-name-validator@npm:5.0.0"
-  checksum: 10c0/3fcf44e7b73fb18be917fdd4ccffff3639373c7cb83f8fc35df6001fecba7942f1dbead29d91ebb8315e2f2ff786b508f0c9dc0215b6353f9983c6b7d62cb1f5
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -5827,15 +5827,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/sax@npm:^1.2.7":
-  version: 1.2.7
-  resolution: "@types/sax@npm:1.2.7"
-  dependencies:
-    "@types/node": "npm:*"
-  checksum: 10c0/d077a761a0753b079bf8279b3993948030ca86ed9125437b9b29c1de40db9b2deb7fddc369f014b58861d450e8b8cc75f163aa29dc8cea81952efbfd859168cf
-  languageName: node
-  linkType: hard
-
 "@types/semver@npm:^7.3.12":
   version: 7.7.1
   resolution: "@types/semver@npm:7.7.1"
@@ -8408,7 +8399,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"debug@npm:4, debug@npm:^4.1.0, debug@npm:^4.1.1, debug@npm:^4.3.1, debug@npm:^4.3.2, debug@npm:^4.3.4, debug@npm:^4.3.5, debug@npm:^4.3.6, debug@npm:^4.4.0, debug@npm:^4.4.1, debug@npm:^4.4.3":
+"debug@npm:4, debug@npm:^4.1.0, debug@npm:^4.1.1, debug@npm:^4.3.1, debug@npm:^4.3.2, debug@npm:^4.3.4, debug@npm:^4.3.5, debug@npm:^4.4.0, debug@npm:^4.4.1, debug@npm:^4.4.3":
   version: 4.4.3
   resolution: "debug@npm:4.4.3"
   dependencies:
@@ -10876,7 +10867,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"foreground-child@npm:^3.1.0, foreground-child@npm:^3.3.1":
+"foreground-child@npm:^3.1.0":
   version: 3.3.1
   resolution: "foreground-child@npm:3.3.1"
   dependencies:
@@ -11165,22 +11156,6 @@ __metadata:
   bin:
     glob: dist/esm/bin.mjs
   checksum: 10c0/100705eddbde6323e7b35e1d1ac28bcb58322095bd8e63a7d0bef1a2cdafe0d0f7922a981b2b48369a4f8c1b077be5c171804534c3509dfe950dde15fbe6d828
-  languageName: node
-  linkType: hard
-
-"glob@npm:^11.0.0":
-  version: 11.1.0
-  resolution: "glob@npm:11.1.0"
-  dependencies:
-    foreground-child: "npm:^3.3.1"
-    jackspeak: "npm:^4.1.1"
-    minimatch: "npm:^10.1.1"
-    minipass: "npm:^7.1.2"
-    package-json-from-dist: "npm:^1.0.0"
-    path-scurry: "npm:^2.0.0"
-  bin:
-    glob: dist/esm/bin.mjs
-  checksum: 10c0/1ceae07f23e316a6fa74581d9a74be6e8c2e590d2f7205034dd5c0435c53f5f7b712c2be00c3b65bf0a49294a1c6f4b98cd84c7637e29453b5aa13b79f1763a2
   languageName: node
   linkType: hard
 
@@ -12357,7 +12332,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"jackspeak@npm:^4.1.1, jackspeak@npm:^4.2.3":
+"jackspeak@npm:^4.2.3":
   version: 4.2.3
   resolution: "jackspeak@npm:4.2.3"
   dependencies:
@@ -14538,7 +14513,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"minimatch@npm:^10.1.1, minimatch@npm:^10.2.1":
+"minimatch@npm:^10.2.1":
   version: 10.2.1
   resolution: "minimatch@npm:10.2.1"
   dependencies:
@@ -16034,7 +16009,6 @@ __metadata:
     react-native: "npm:^0.84.0"
     react-native-builder-bob: "npm:^0.40.18"
     svg2ttf: "npm:^6.0.3"
-    svgicons2svgfont: "npm:^15.0.1"
     typescript: "npm:^5.9.3"
     xcode: "npm:^3.0.1"
   peerDependencies:
@@ -16916,7 +16890,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"sax@npm:>=0.6.0, sax@npm:^1.4.1":
+"sax@npm:>=0.6.0":
   version: 1.4.4
   resolution: "sax@npm:1.4.4"
   checksum: 10c0/acb642f2de02ad6ae157cbf91fb026acea80cdf92e88c0aec2aa350c7db3479f62a7365c34a58e3b70a72ce11fa856a02c38cfd27f49e83c18c9c7e1d52aee55
@@ -17850,13 +17824,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"svg-pathdata@npm:^7.0.0":
-  version: 7.2.0
-  resolution: "svg-pathdata@npm:7.2.0"
-  checksum: 10c0/53feec22dc8310d8062c5e6cabe86dfe8944f699306783c230e20dfd403943b4d9c860fa2a559b0fbca3455a467cc892b193b32f66c1bf07c0e0ac75fb6e0521
-  languageName: node
-  linkType: hard
-
 "svg2ttf@npm:^6.0.3":
   version: 6.0.3
   resolution: "svg2ttf@npm:6.0.3"
@@ -17870,24 +17837,6 @@ __metadata:
   bin:
     svg2ttf: svg2ttf.js
   checksum: 10c0/6087f988beb807fda5ff55e3bb14dcf36b4dfdcc8857720310b0b281ad5f9d504025629c842dff14861cdfb7fe01ba5947850311e2e897797a96b907b4276a82
-  languageName: node
-  linkType: hard
-
-"svgicons2svgfont@npm:^15.0.1":
-  version: 15.0.1
-  resolution: "svgicons2svgfont@npm:15.0.1"
-  dependencies:
-    "@types/sax": "npm:^1.2.7"
-    commander: "npm:^12.1.0"
-    debug: "npm:^4.3.6"
-    glob: "npm:^11.0.0"
-    sax: "npm:^1.4.1"
-    svg-pathdata: "npm:^7.0.0"
-    transformation-matrix: "npm:^3.0.0"
-    yerror: "npm:^8.0.0"
-  bin:
-    svgicons2svgfont: bin/svgicons2svgfont.js
-  checksum: 10c0/f197500622538b0875548f554bb5b371b23883b34fb9dac8c1fac72feb01c789edcae76fd077c768f76d63ac3eec032d9535aa83b841d65851e8e0a491bd03c1
   languageName: node
   linkType: hard
 
@@ -18147,13 +18096,6 @@ __metadata:
   version: 0.0.3
   resolution: "tr46@npm:0.0.3"
   checksum: 10c0/047cb209a6b60c742f05c9d3ace8fa510bff609995c129a37ace03476a9b12db4dbf975e74600830ef0796e18882b2381fb5fb1f6b4f96b832c374de3ab91a11
-  languageName: node
-  linkType: hard
-
-"transformation-matrix@npm:^3.0.0":
-  version: 3.1.0
-  resolution: "transformation-matrix@npm:3.1.0"
-  checksum: 10c0/f26b1902994b35b293c5d3d5f58906309f04a6b0c1b74abef03cc9003e440c1a24497c9e80f911d9296fa7c22e464208a9b1064aafa141405a6da8267f83952d
   languageName: node
   linkType: hard
 
@@ -19253,13 +19195,6 @@ __metadata:
     y18n: "npm:^5.0.5"
     yargs-parser: "npm:^21.1.1"
   checksum: 10c0/ccd7e723e61ad5965fffbb791366db689572b80cca80e0f96aad968dfff4156cd7cd1ad18607afe1046d8241e6fb2d6c08bf7fa7bfb5eaec818735d8feac8f05
-  languageName: node
-  linkType: hard
-
-"yerror@npm:^8.0.0":
-  version: 8.0.0
-  resolution: "yerror@npm:8.0.0"
-  checksum: 10c0/bb2ea224c267294eb5087a9f1c247a7acd5820b4abb480e604f7fcaf5db452900092fc5e0b895a604c062b233336cb9bd68ee1c0704856f58c041d07371e5cfa
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Description

<!--
Description and motivation for this PR.

Include 'Fixes #<number>' if this is fixing some issue.
-->
This PR considers the following:
- Replace jsdom with fast-xml-parser for SVG attribute/path parsing
We agree jsdom is a massive overkill for the task, but we don't think `fast-xml-parser` is the solution. We decided to replace `jsdom` with `xmldom`, because it is as close to a drop-in replacement as possible, it is a really small bundle with no runtime deps, and unlike `fast-xml-parser` it uses DOM instead of plain js object tree, so we do not need to implement own tree traversal and ancestor walk 

- Remove unused svgicons2svgfont
We agree this is a good idea, `svgicons2svgfont` is not used anywhere

- Replace ora with yocto-spinner or similar for the CLI logger
We decided against it as it does not influence the performance (used only at build time) and ora isn't a massive overkill - we might actually use more of its features in the future

## Test plan
jsdom -> xmldom isn't really a big API change, so just few end to end tests and making sure all unit tests pass
<!--
Describe how did you test this change here.
-->
