### PR TITLE
fix: ios misrender

### DIFF
--- a/packages/react-native-nano-icons/ios/NanoIconView.mm
+++ b/packages/react-native-nano-icons/ios/NanoIconView.mm
@@ -175,11 +175,21 @@ static CTFontRef NanoIconGetCachedFont(NSString *family, CGFloat size) {
   _drawingLayer = layer;
 }
 
-// Re-detect inline state when the view moves to a new parent.
+// Reset inline state when the view moves to a new parent. Fabric recycles
+// view instances across mount points, so derived state (_isInlineInText,
+// _drawingLayer) from a prior incarnation must be cleared — otherwise an
+// updateProps that arrives before the next layout pass will redraw into the
+// stale layer, producing a duplicate render on top of drawRect: on self.
 - (void)didMoveToSuperview {
   [super didMoveToSuperview];
   _inlineDetected = NO;
+  _isInlineInText = NO;
+  _paragraphView = nil;
   _baselineOffsetValid = NO;
+  if (_drawingLayer) {
+    [_drawingLayer removeFromSuperlayer];
+    _drawingLayer = nil;
+  }
 }
 
 // Invalidate cached offset when size changes (text relayout).

--- a/packages/react-native-nano-icons/ios/NanoIconView.mm
+++ b/packages/react-native-nano-icons/ios/NanoIconView.mm
@@ -175,11 +175,7 @@ static CTFontRef NanoIconGetCachedFont(NSString *family, CGFloat size) {
   _drawingLayer = layer;
 }
 
-// Reset inline state when the view moves to a new parent. Fabric recycles
-// view instances across mount points, so derived state (_isInlineInText,
-// _drawingLayer) from a prior incarnation must be cleared — otherwise an
-// updateProps that arrives before the next layout pass will redraw into the
-// stale layer, producing a duplicate render on top of drawRect: on self.
+// Reset inline state when the view moves to a new parent.
 - (void)didMoveToSuperview {
   [super didMoveToSuperview];
   _inlineDetected = NO;


### PR DESCRIPTION
## Description
NanoIconView can have two drawing modes: stanalone and inline. Fabric (rendering engine) reuses view instances - this makes perfect sense, but due to the possibility of being used in the other drawing mode we need to handle clenup. 

This was the snippet responsible for that:
```
- (void)didMoveToSuperview {
  [super didMoveToSuperview];
  _inlineDetected = NO;
  _baselineOffsetValid = NO;
}
```
Two things are missing:
- _isInlineInText is still YES from the prior mount.
- _drawingLayer is still attached as a sublayer of self, with its previous rendered contents

Then when the new icon comes, `if (_isInlineInText && _drawingLayer) ` fires, both are still true from the stale incarnation.The old sublayer with the new icon gets redrawn.
After that `drawRect`  runs on self and paints the new icon at the standalone origin.

Thus we get two icons drawn.

## Fix
Propoer clean-up:
```
// Reset inline state when the view moves to a new parent.
- (void)didMoveToSuperview {
  [super didMoveToSuperview];
  _inlineDetected = NO;
  _isInlineInText = NO;
  _paragraphView = nil;
  _baselineOffsetValid = NO;
  if (_drawingLayer) {
    [_drawingLayer removeFromSuperlayer];
    _drawingLayer = nil;
  }
}
```
<!--
Description and motivation for this PR.

Include 'Fixes #<number>' if this is fixing some issue.
-->

## Test plan

<!--
Describe how did you test this change here.
-->
Before (some overlap when aggressive view recycling):
<img width="231" height="176" alt="image" src="https://github.com/user-attachments/assets/64f70d5c-8b80-41e4-a10e-fea0066d51d5" />

After:
<img width="227" height="163" alt="image" src="https://github.com/user-attachments/assets/37072e0b-292b-4b92-8fbf-195ee1783783" />

