### PR TITLE
fix: ios incremental builds

### DIFF
--- a/packages/react-native-nano-icons/plugin/src/withNanoIconsFontLinking.ts
+++ b/packages/react-native-nano-icons/plugin/src/withNanoIconsFontLinking.ts
@@ -11,9 +11,15 @@ import { getOrBuildFonts } from './buildFonts.js';
 import type { IconSetConfig } from './types.js';
 
 const ANDROID_ASSETS_FONTS_DIR = 'app/src/main/assets/fonts';
+const IOS_FONTS_GROUP = 'Resources';
 
 /**
  * Add TTFs to the iOS project (Resources group + UIAppFonts in Info.plist).
+ *
+ * Copies each .ttf into ios/<projectName>/Resources/ on every prebuild so that
+ * Xcode's incremental build reliably picks up updated glyph data. Referencing
+ * the .ttf via a relative path outside ios/ leaves stale fonts in the .app
+ * bundle when only the file contents change.
  */
 export function withNanoIconsIos(
   config: Parameters<typeof withXcodeProject>[0],
@@ -25,15 +31,25 @@ export function withNanoIconsIos(
       iconSets
     );
     if (!built?.length) return config;
-    const ttfPaths = built.map((b) => b.ttfPath);
     const project = config.modResults;
     const platformProjectRoot = config.modRequest.platformProjectRoot;
-    IOSConfig.XcodeUtils.ensureGroupRecursively(project, 'Resources');
-    for (const fontPath of ttfPaths) {
-      const relativePath = path.relative(platformProjectRoot, fontPath);
+    const projectName =
+      config.modRequest.projectName ??
+      IOSConfig.XcodeUtils.getProjectName(config.modRequest.projectRoot);
+    const fontsDir = path.join(
+      platformProjectRoot,
+      projectName,
+      IOS_FONTS_GROUP
+    );
+    await fs.mkdir(fontsDir, { recursive: true });
+    IOSConfig.XcodeUtils.ensureGroupRecursively(project, IOS_FONTS_GROUP);
+    for (const { ttfPath } of built) {
+      const dest = path.join(fontsDir, path.basename(ttfPath));
+      await fs.copyFile(ttfPath, dest);
+      const relativePath = path.relative(platformProjectRoot, dest);
       IOSConfig.XcodeUtils.addResourceFileToGroup({
         filepath: relativePath,
-        groupName: 'Resources',
+        groupName: IOS_FONTS_GROUP,
         project,
         isBuildFile: true,
         verbose: true,


### PR DESCRIPTION
## Description
Running expo prebuild for the second time after adding new svg icon, doesn't ship the new glyph to the ios build. 

Bug:
The bug is a combination of few things. First of all, the rendered .ttf files are located and imported from outside of ios/ folder (../assets/nanoicons/<name>.ttf). This makes Xcode's incremental resource tracking lost. Then on second prebuild `expo/config-plugins`' rejects duplicates by basename alone (just how it works) thus making the pbxproj bit-identical as before.

Now with no pbxproj diff to invalidate Xcode's build database, and a source path that crosses out of ios/ (which Xcode's incremental resource tracking handles unreliably),  the previously bundled .ttf remains


Solution:
Basically copy what android was already doing - stage .ttf files inside the platform project tree and let the Xcode's resorce tracking do the heavy lifting. We modified `withNanoIconsFontLinking.ts` to copy the file into the fonts directory inside the ios/ folder
<!--
Description and motivation for this PR.

Include 'Fixes #<number>' if this is fixing some issue.
-->

## Test plan
I did manual testing:
- clean build
- shasum of the staged .ttf
- added new replacement svg
- did a expo prebuild (without --clean)
- calculated another shasum and they turned out different
<!--
Describe how did you test this change here.
-->

If you have an existing project, a one time expo prebuild --clean is needed to get rid of the old ttf.