### PR TITLE
fix: codegen type alias resolution on rn <=0.79

### DIFF
--- a/packages/react-native-nano-icons/src/const/codegenPrimitives.ts
+++ b/packages/react-native-nano-icons/src/const/codegenPrimitives.ts
@@ -1,0 +1,14 @@
+// Local numeric aliases for RN codegen TS spec parsing.
+//
+// RN 0.79 and lower's codegen resolves any TSTypeAliasDeclaration found in the spec
+// file back to its original RHS before the array-element handler runs — so a
+// local `type Int32 = CodegenTypes.Int32` still presents as a TSQualifiedName
+// inside ReadonlyArray<> and trips "Unknown prop type ... TSTypeReference".
+// Imported identifiers are NOT tracked in the codegen's known-types map, so
+// importing `Int32` / `Float` from here leaves a bare identifier that matches
+// the primitive-type branch (`case 'Int32'` / `case 'Float'`).
+//
+// These are pure number aliases at runtime; RN codegen only cares about the
+// identifier name.
+export type Int32 = number;
+export type Float = number;

--- a/packages/react-native-nano-icons/src/specs/NanoIconViewNativeComponent.ts
+++ b/packages/react-native-nano-icons/src/specs/NanoIconViewNativeComponent.ts
@@ -1,15 +1,16 @@
 import { codegenNativeComponent } from 'react-native';
-import type { CodegenTypes as CT, ViewProps } from 'react-native';
+import type { ViewProps } from 'react-native';
+import type { Float, Int32 } from '../const/codegenPrimitives';
 
 export interface NativeProps extends ViewProps {
   fontFamily: string;
-  codepoints: ReadonlyArray<CT.Int32>;
-  colors: ReadonlyArray<CT.Int32>;
-  fontSize: CT.Float;
-  advanceWidth: CT.Int32;
-  unitsPerEm: CT.Int32;
-  iconWidth: CT.Float;
-  iconHeight: CT.Float;
+  codepoints: ReadonlyArray<Int32>;
+  colors: ReadonlyArray<Int32>;
+  fontSize: Float;
+  advanceWidth: Int32;
+  unitsPerEm: Int32;
+  iconWidth: Float;
+  iconHeight: Float;
 }
 
 export default codegenNativeComponent<NativeProps>('NanoIconView');

--- a/packages/react-native-nano-icons/tsconfig.json
+++ b/packages/react-native-nano-icons/tsconfig.json
@@ -28,5 +28,6 @@
     "strict": true,
     "target": "ESNext",
     "verbatimModuleSyntax": true
-  }
+  },
+  "exclude": ["lib"]
 }


### PR DESCRIPTION
## Description

  Makes the NanoIconView Fabric (New Architecture) spec generate correctly across React Native 0.76 → 0.85 simultaneously.

  The spec previously typed its numeric props with the CodegenTypes namespace, e.g. ReadonlyArray<CT.Int32>. Two problems on older RN:

  - The CodegenTypes namespace export (`import { CodegenTypes } from 'react-native'`) only exists from RN 0.80.
  - On RN ≤ 0.79, the codegen TypeScript parser only takes the rightmost identifier of a TSQualifiedName and fails to resolve it inside ReadonlyArray<…>, so codegen errors with Unknown prop type … TSTypeReference and
  breaks pod install / the native build.

  Because the package opts into RN's Strict TypeScript API (`customConditions: ["react-native-strict-api"]`), the usual ecosystem workaround — importing primitives from the deep path
  react-native/Libraries/Types/CodegenTypes — isn't available (the Strict API blocks deep imports).

  Fix: `add src/const/codegenPrimitives.ts` that re-declares the primitives as plain numeric aliases (export type Int32 = number; export type Float = number;) and import them as bare identifiers in the spec. RN codegen
  matches primitives by identifier name and does not follow imports, so a bare Int32 hits the primitive branch (case 'Int32') on every supported version, while staying compatible with the Strict TypeScript API. Also
  excludes lib from typechecking in tsconfig.json.
  
 The support for rn <0.80 will be dropped eventually, which will make this fix redundant, however a decision was made to use it instead of opting out of the `react-native-strict-api` ts rule.

## Test plan

  - [x] yarn typecheck passes (spec type-checks under the Strict TypeScript API).
  - [x] yarn test 
  - [x] yarn build
  - [x] tested on all latest minor rn versions from 0.76 to rn@next with and w/o expo
