### PR TITLE
fix: use scaled native icon font size

### DIFF
--- a/packages/react-native-nano-icons/src/createNanoIconsSet.native.tsx
+++ b/packages/react-native-nano-icons/src/createNanoIconsSet.native.tsx
@@ -123,7 +123,7 @@ export function createIconSet<GM extends NanoGlyphMapInput>(
           fontFamily={fontFamilyBasename}
           codepoints={codepoints}
           colors={processedColors}
-          fontSize={size}
+          fontSize={scaledSize}
           advanceWidth={adv}
           unitsPerEm={unitsPerEm}
           iconWidth={width}


### PR DESCRIPTION
## Problem

On Android, native icons pass the raw `size` value to `NanoIconViewNative` as `fontSize`, while the layout height and icon height already use `scaledSize`. The issue is reproducible by changing the system font size in either direction, smaller or larger, when `allowFontScaling` is enabled: the rendered glyph size can diverge from the scaled native view dimensions.

## Solution

Pass `scaledSize` to the native `fontSize` prop so the glyph size matches the scaled layout and icon dimensions.

## Screenshots (font size scaled down in system settings)

| Before | After |
| --- | --- |
| <img width="534" height="991" alt="Screenshot 2026-06-03 at 00 54 32" src="https://github.com/user-attachments/assets/029fc874-703e-4d7f-906a-22fc3608e1ed" /> | <img width="534" height="991" alt="Screenshot 2026-06-03 at 00 56 33" src="https://github.com/user-attachments/assets/d7d09abe-00d7-4b9f-a022-3e3d4e27a530" /> |
