### PR TITLE
fix: preserve hardcoded fills when a single color is passed

### DIFF
--- a/packages/react-native-nano-icons/src/createNanoIconsSet.native.tsx
+++ b/packages/react-native-nano-icons/src/createNanoIconsSet.native.tsx
@@ -101,7 +101,16 @@ export function createIconSet<GM extends NanoGlyphMapInput>(
         if (color === undefined || color === null) {
           return getDefaultColors(nameStr, layers);
         }
-        const colorArray = Array.isArray(color) ? color : [color];
+        // Single color: tint only layers authored with currentColor
+        // Layers with hardcoded fills (flags, logos, ...) keep their source colors
+        if (!Array.isArray(color)) {
+          return layers.map(([, srcColor]) =>
+            cachedProcessColor(
+              (srcColor === 'currentColor' ? color : srcColor ?? 'black') as string
+            )
+          );
+        }
+        const colorArray = color;
         const lastPaletteColor = colorArray.length
           ? colorArray[colorArray.length - 1]
           : undefined;

--- a/packages/react-native-nano-icons/src/createNanoIconsSet.shared.tsx
+++ b/packages/react-native-nano-icons/src/createNanoIconsSet.shared.tsx
@@ -51,6 +51,23 @@ export function createJSIconSet<GM extends NanoGlyphMapInput>(
     return ch;
   };
 
+  // Single color: tint only layers authored with currentColor
+  // Layers with hardcoded fills (flags, logos, ...) keep their source colors
+  function resolveLayerColor(
+    color: IconProps<keyof GM['i']>['color'],
+    srcColor: string | undefined,
+    index: number
+  ): string {
+    if (Array.isArray(color)) {
+      const last = color.length ? color[color.length - 1] : undefined;
+      return (color[index] ?? last ?? srcColor ?? 'black') as string;
+    }
+    if (color != null && srcColor === 'currentColor') {
+      return color as string;
+    }
+    return srcColor ?? 'black';
+  }
+
   const Icon = memo(
     ({
       name,
@@ -71,11 +88,6 @@ export function createJSIconSet<GM extends NanoGlyphMapInput>(
       const scaledSize = size * fontScale;
       const width = (adv / unitsPerEm) * scaledSize;
 
-      const colorArray = Array.isArray(color) ? color : [color];
-      const lastPaletteColor = colorArray?.length
-        ? colorArray[colorArray.length - 1]
-        : undefined;
-
       const containerStyle = useMemo(
         () => [{ height: scaledSize, width, bottom: 0 as const }, style],
         [scaledSize, width, style]
@@ -94,8 +106,7 @@ export function createJSIconSet<GM extends NanoGlyphMapInput>(
           importantForAccessibility={importantForAccessibility}
           testID={testID}>
           {layers.map(([codepoint, srcColor], i) => {
-            const layerColor =
-              colorArray?.[i] ?? lastPaletteColor ?? srcColor ?? 'black';
+            const layerColor = resolveLayerColor(color, srcColor, i);
 
             return (
               <Text


### PR DESCRIPTION
Right now, passing a single `color` string to an icon repaints every layer, so a country flag or payment logo just becomes a monochrome blob. The only way around it is to build a per-layer color array yourself, which is clunky for what should be the simple case. It also defeats `React.memo` unless you go out of your way to memoize the array.

The glyph map already knows the difference between layers authored with `currentColor` and layers with hardcoded fills like `#c0ffee`. That distinction exists in the data, it's just being thrown away at render time. Since the library resolves layer colors manually on every platform (even on web it's `<Text>` elements, not actual SVGs), there's nothing preventing it from doing the right thing here. On the web, `fill="currentColor"` inherits and `fill="#c0ffee"` stays put. The glyph map already encodes that intent, might as well honor it.

This is a breaking change for anyone relying on single-color to repaint the entire icon, including hardcoded layers. But I think the current behavior is just wrong. It's surprising, it breaks multi-color icons, and the workaround has real performance implications. The array form still gives you full per-layer control if you need it.

**What changed:**
- **Native path** (`createNanoIconsSet.native.tsx`): when `color` is a non-array string, early-return a map that only replaces `currentColor` entries, skipping the `colorArray` fallback chain.
- **Shared/JS path** (`createNanoIconsSet.shared.tsx`): same logic extracted into a `resolveLayerColor` helper with the same early-return pattern as the native path.

| | Single color `"#333"` | Color array `["red", "blue"]` |
|---|---|---|
| **Before** | All layers become `#333` | Per-layer as expected |
| **After** | Only `currentColor` layers become `#333`; hardcoded fills preserved | Per-layer as expected (unchanged) |