### PR TITLE
fix(ios): clear inline layer on Fabric view recycle to prevent ghost glyphs

### DIFF
--- a/packages/react-native-nano-icons/ios/NanoIconView.mm
+++ b/packages/react-native-nano-icons/ios/NanoIconView.mm
@@ -188,6 +188,28 @@ static CTFontRef NanoIconGetCachedFont(NSString *family, CGFloat size) {
   }
 }
 
+// Fabric recycles component views. Without a reset, a recycled view keeps the
+// previous icon's inline drawing sublayer (and drawRect backing store), which
+// shows up as ghost glyphs from another icon overlapping the new one.
+// Only rendered content and inline-mode state are reset here: _glyphs/_colors
+// must stay consistent with _props, which Fabric preserves across recycling
+// (updateProps only rebuilds them when the new props differ).
+- (void)prepareForRecycle {
+  [super prepareForRecycle];
+  if (_drawingLayer) {
+    [_drawingLayer removeFromSuperlayer];
+    _drawingLayer = nil;
+  }
+  _inlineDetected = NO;
+  _isInlineInText = NO;
+  _paragraphView = nil;
+  _cachedBaselineOffset = 0;
+  _baselineOffsetValid = NO;
+  _metricsValid = NO;
+  self.layer.contents = nil;
+  [self setNeedsDisplay];
+}
+
 // Invalidate cached offset when size changes (text relayout).
 - (void)setBounds:(CGRect)bounds {
   if (!CGSizeEqualToSize(self.bounds.size, bounds.size)) {
@@ -225,7 +247,18 @@ static CTFontRef NanoIconGetCachedFont(NSString *family, CGFloat size) {
     }
     // First layout after inline detection: the layer missed the initial
     // setNeedsDisplay from updateProps (which targeted self before detection).
-    if (created) [_drawingLayer setNeedsDisplay];
+    // Also clear self's backing store in case this view previously drew as a
+    // standalone icon (drawRect early-returns for inline, so this only wipes).
+    if (created) {
+      [_drawingLayer setNeedsDisplay];
+      [self setNeedsDisplay];
+    }
+  } else if (_drawingLayer) {
+    // Switched inline -> standalone (reparent/recycle): drop the stale inline
+    // layer or its old glyph keeps compositing on top of the new icon.
+    [_drawingLayer removeFromSuperlayer];
+    _drawingLayer = nil;
+    [self setNeedsDisplay];
   }
   // standalone: draws directly via drawRect: on self
 }
@@ -377,11 +410,11 @@ static CTFontRef NanoIconGetCachedFont(NSString *family, CGFloat size) {
 
   [super updateProps:props oldProps:oldProps];
   if (needsRedraw) {
-    if (_isInlineInText && _drawingLayer) {
-      [_drawingLayer setNeedsDisplay];
-    } else {
-      [self setNeedsDisplay];
-    }
+    // _isInlineInText may be stale here (re-detection happens at layout), so
+    // mark both targets; drawRect/drawInContext render per the resolved mode
+    // and the redundant invalidation only clears the unused backing store.
+    [_drawingLayer setNeedsDisplay];
+    [self setNeedsDisplay];
   }
 }
 


### PR DESCRIPTION
## Description

`NanoIconView` lazily allocates a `NanoIconDrawingLayer` for inline-in-`<Text>` rendering. Under Fabric, the same view instance is recycled across rows that alternate between inline and standalone usage. The leftover inline layer keeps compositing the previous icon on top of the new render, producing visible **ghost glyphs** while a list scrolls.

The bug reproduces on iOS Simulator with RN 0.85.3 (Fabric) in a busy `FlatList` whose rows mix inline-in-`<Text>` and standalone `<NanoIcon>` usage — within seconds of scrolling, recycled views paint their previous icon on top of the new one.

### Changes

1. **Add `-prepareForRecycle`** — drop the inline layer, reset inline-mode state, clear the backing store, and trigger a redraw. `didMoveToSuperview` doesn't always fire on Fabric recycle, so this is the reliable hook for the lifecycle.
2. **`-layoutSubviews`** — when a view transitions inline → standalone via recycle, drop the stale `_drawingLayer` instead of leaving it parented. Also clear `self`'s backing store on the first layout after inline detection (a previous standalone draw could otherwise linger).
3. **`-updateProps`** — invalidate both targets unconditionally. `_isInlineInText` is set in layout, so it can be stale at the point `updateProps` runs. `drawRect`/`drawInContext` render per the resolved mode, and the redundant invalidation only wipes the unused backing store.

`_glyphs` / `_colors` / `_props` are intentionally **not** reset in `prepareForRecycle` — Fabric preserves the `Props` object across recycling and `updateProps` rebuilds the caches only when props differ, so wiping them here would either be redundant or strand the view with empty render state.

## Test plan

- Minimal repro app: `FlatList` of 400 rows where each row is either inline-in-`<Text>` or standalone `<NanoIcon>`, auto-scrolled rapidly.
- Without this fix: ghost glyphs appear within seconds of starting auto-scroll, with overlapping/stale icons clearly visible on recycled rows.
- With this fix applied: no ghost glyphs observed during sustained auto-scroll on the same device/build.
- Verified on iPhone 17 Simulator (iOS 26.5), Xcode 26.5, RN 0.85.3 Fabric.