### PR TITLE
feat: font linking as build script / gradle task

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,10 +154,27 @@ Bare apps don't have a prebuild step, so you run the same pipeline via the CLI:
 2. **Build and link** – From the app root run:
 
    ```sh
-   npx react-native-nano-icons --path path/to/.nanoicons.json
+   npx react-native-nano-icons
    ```
 
-   This works exactly like the config plugin, removing any necessity for manual Xcode/Android Studio font linking steps.
+   This works exactly like the config plugin, removing any necessity for manual Xcode/Android Studio font linking steps. It looks for `.nanoicons.json` in the current directory and searches upward. Pass `--path <dir|file>` to point at it explicitly.
+
+##### Generate fonts automatically on every native build (optional)
+
+Wire generation into the native build so fonts are regenerated and linked whenever you build the app.
+
+**iOS** – running `npx react-native-nano-icons` once installs an Xcode "Copy nanoicons fonts" Run Script phase that regenerates and copies the fonts on each build. No further action needed - just rebuild from Xcode or `npx react-native run-ios`.
+
+**Android** – add one line to `android/app/build.gradle`:
+
+```gradle
+apply from: file("../../node_modules/react-native-nano-icons/android/nanoicons.gradle")
+```
+
+This registers a `nanoiconsGenerate` task that runs before `preBuild` and copies the fonts into `android/app/src/main/assets/fonts`.
+
+Both hooks call `react-native-nano-icons generate --platform <ios|android>`, which only rebuilds when your SVGs change (fingerprint cache) and never mutates your Xcode project or `Info.plist`, so it is safe to run on every build.
+
 
 > [!TIP]
 > Run `EXPO_DEBUG=1 npx expo prebuild` or `npx react-native-nano-icons --verbose` to get font build-time logs.

--- a/examples/BareReactNativeExample/android/app/build.gradle
+++ b/examples/BareReactNativeExample/android/app/build.gradle
@@ -2,6 +2,9 @@ apply plugin: "com.android.application"
 apply plugin: "org.jetbrains.kotlin.android"
 apply plugin: "com.facebook.react"
 
+// Regenerate + copy nano-icons fonts into assets on every build.
+apply from: file("../../node_modules/react-native-nano-icons/android/nanoicons.gradle")
+
 /**
  * This is the configuration block to customize your React Native Android app.
  * By default you don't need to apply any configuration, just uncomment the lines you need.

--- a/packages/react-native-nano-icons/__tests__/config.unit.test.ts
+++ b/packages/react-native-nano-icons/__tests__/config.unit.test.ts
@@ -1,0 +1,67 @@
+/** @jest-environment node */
+
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import { resolveConfigPath, CONFIG_FILENAME } from '../cli/config';
+
+function makeTmpDir(): string {
+  // realpathSync resolves macOS /var → /private/var so path assertions match.
+  return fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), 'nano-cfg-')));
+}
+
+function writeConfig(dir: string): string {
+  fs.mkdirSync(dir, { recursive: true });
+  const configPath = path.join(dir, CONFIG_FILENAME);
+  fs.writeFileSync(
+    configPath,
+    JSON.stringify({ iconSets: [{ inputDir: './icons' }] })
+  );
+  return configPath;
+}
+
+describe('resolveConfigPath', () => {
+  let root: string;
+
+  beforeEach(() => {
+    root = makeTmpDir();
+  });
+
+  afterEach(() => {
+    fs.rmSync(root, { recursive: true, force: true });
+  });
+
+  test('explicit path accepts a directory or a direct file', () => {
+    const configDir = path.join(root, 'config');
+    const configPath = writeConfig(configDir);
+
+    expect(resolveConfigPath({ explicit: configDir, startDir: root })).toEqual({
+      configPath,
+      configRoot: configDir,
+    });
+    expect(resolveConfigPath({ explicit: configPath, startDir: root })).toEqual(
+      {
+        configPath,
+        configRoot: configDir,
+      }
+    );
+  });
+
+  test('searches upward when no explicit path is given', () => {
+    const configPath = writeConfig(root);
+    const deep = path.join(root, 'android', 'app', 'src');
+    fs.mkdirSync(deep, { recursive: true });
+
+    expect(resolveConfigPath({ startDir: deep })).toEqual({
+      configPath,
+      configRoot: root,
+    });
+  });
+
+  test('throws a helpful error when nothing is found', () => {
+    expect(() => resolveConfigPath({ startDir: root })).toThrow(
+      /Could not locate/
+    );
+  });
+});

--- a/packages/react-native-nano-icons/__tests__/stageFonts.unit.test.ts
+++ b/packages/react-native-nano-icons/__tests__/stageFonts.unit.test.ts
@@ -1,0 +1,183 @@
+/** @jest-environment node */
+
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import * as plist from 'plist';
+
+import { stageFonts } from '../cli/link';
+import type { NanoLogger } from '../cli/logger';
+import type { BuiltFont } from '../cli/build';
+
+const ANDROID_FONTS_DIR = 'android/app/src/main/assets/fonts';
+const IOS_STAGING_DIR = 'ios/nanoicons-fonts';
+
+function makeTmpDir(): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'nano-stage-'));
+}
+
+function makeLogger(): NanoLogger {
+  return {
+    start: jest.fn(),
+    update: jest.fn(),
+    succeed: jest.fn(),
+    fail: jest.fn(),
+    info: jest.fn(),
+    warn: jest.fn(),
+  };
+}
+
+describe('stageFonts — per-build staging', () => {
+  let projectRoot: string;
+  let fontDir: string;
+
+  function builtFont(
+    fontFamily: string,
+    linking: 'static' | 'dynamic' = 'static'
+  ): BuiltFont {
+    const ttfPath = path.join(fontDir, `${fontFamily}.ttf`);
+    fs.writeFileSync(ttfPath, 'fake-ttf');
+    return {
+      fontFamily,
+      ttfPath,
+      glyphmapPath: path.join(fontDir, `${fontFamily}.glyphmap.json`),
+      linking,
+    };
+  }
+
+  function addIos(uiAppFonts?: string[]): string {
+    const iosDir = path.join(projectRoot, 'ios');
+    fs.mkdirSync(path.join(iosDir, 'MyApp'), { recursive: true });
+    const infoPlistPath = path.join(iosDir, 'MyApp', 'Info.plist');
+    fs.writeFileSync(
+      infoPlistPath,
+      plist.build(
+        uiAppFonts
+          ? { CFBundleName: 'placeholder', UIAppFonts: uiAppFonts }
+          : { CFBundleName: 'placeholder' }
+      )
+    );
+    return infoPlistPath;
+  }
+
+  function addAndroid(): void {
+    fs.mkdirSync(path.join(projectRoot, 'android'), { recursive: true });
+  }
+
+  beforeEach(() => {
+    projectRoot = makeTmpDir();
+    fontDir = makeTmpDir();
+  });
+
+  afterEach(() => {
+    fs.rmSync(projectRoot, { recursive: true, force: true });
+    fs.rmSync(fontDir, { recursive: true, force: true });
+  });
+
+  test('android: copies static TTFs into assets/fonts, skips dynamic', async () => {
+    addAndroid();
+
+    await stageFonts(
+      projectRoot,
+      [builtFont('StaticA'), builtFont('DynA', 'dynamic')],
+      'android',
+      makeLogger()
+    );
+
+    const fontsDir = path.join(projectRoot, ANDROID_FONTS_DIR);
+    expect(fs.existsSync(path.join(fontsDir, 'StaticA.ttf'))).toBe(true);
+    expect(fs.existsSync(path.join(fontsDir, 'DynA.ttf'))).toBe(false);
+  });
+
+  test('ios: copies static TTFs into the staging dir, skips dynamic', async () => {
+    addIos();
+
+    await stageFonts(
+      projectRoot,
+      [builtFont('StaticB'), builtFont('DynB', 'dynamic')],
+      'ios',
+      makeLogger()
+    );
+
+    const stagingDir = path.join(projectRoot, IOS_STAGING_DIR);
+    expect(fs.existsSync(path.join(stagingDir, 'StaticB.ttf'))).toBe(true);
+    expect(fs.existsSync(path.join(stagingDir, 'DynB.ttf'))).toBe(false);
+  });
+
+  test('ios: does NOT register fonts in Info.plist (contract of the per-build hook)', async () => {
+    const infoPlistPath = addIos(['Existing.ttf']);
+    const before = fs.readFileSync(infoPlistPath, 'utf8');
+
+    await stageFonts(
+      projectRoot,
+      [builtFont('NewFamily')],
+      'ios',
+      makeLogger()
+    );
+
+    // Plist is left byte-for-byte untouched — registration is linkBare's job.
+    const after = fs.readFileSync(infoPlistPath, 'utf8');
+    expect(after).toBe(before);
+
+    const parsed = plist.parse(after) as Record<string, unknown>;
+    expect(parsed['UIAppFonts']).toEqual(['Existing.ttf']);
+  });
+
+  test('ios: does not create or touch an Xcode project file', async () => {
+    addIos();
+
+    await stageFonts(
+      projectRoot,
+      [builtFont('NoProjectEdit')],
+      'ios',
+      makeLogger()
+    );
+
+    const xcodeproj = path.join(projectRoot, 'ios', 'MyApp.xcodeproj');
+    expect(fs.existsSync(xcodeproj)).toBe(false);
+  });
+
+  test('missing platform dir is a safe no-op', async () => {
+    // No android/ directory created.
+    const logger = makeLogger();
+
+    await stageFonts(projectRoot, [builtFont('Whatever')], 'android', logger);
+
+    expect(fs.existsSync(path.join(projectRoot, ANDROID_FONTS_DIR))).toBe(
+      false
+    );
+    expect(logger.succeed).not.toHaveBeenCalled();
+  });
+
+  test('all-dynamic set stages nothing', async () => {
+    addIos();
+    addAndroid();
+    const logger = makeLogger();
+
+    await stageFonts(
+      projectRoot,
+      [builtFont('D1', 'dynamic'), builtFont('D2', 'dynamic')],
+      'ios',
+      logger
+    );
+
+    expect(fs.existsSync(path.join(projectRoot, IOS_STAGING_DIR))).toBe(false);
+    expect(logger.succeed).not.toHaveBeenCalled();
+  });
+
+  test('reports how many fonts were staged', async () => {
+    addAndroid();
+    const logger = makeLogger();
+
+    await stageFonts(
+      projectRoot,
+      [builtFont('S1'), builtFont('S2')],
+      'android',
+      logger
+    );
+
+    expect(logger.succeed).toHaveBeenCalledWith(
+      expect.stringContaining('Staged 2 font(s) → android')
+    );
+  });
+});

--- a/packages/react-native-nano-icons/android/nanoicons.gradle
+++ b/packages/react-native-nano-icons/android/nanoicons.gradle
@@ -1,0 +1,56 @@
+/**
+ * react-native-nano-icons — regenerates icon fonts into assets/fonts on every build.
+ *
+ * Apply from your app module:
+ *   apply from: file("../../node_modules/react-native-nano-icons/android/nanoicons.gradle")
+ *
+ * Optional gradle.properties overrides:
+ *   nanoicons.nodeBinary=node          # node executable
+ *   nanoicons.configPath=config/icons  # only needed if .nanoicons.json is below the root
+ */
+
+// rootProject.projectDir is android/; the JS project root is its parent.
+def nanoiconsProjectRoot = file("${rootProject.projectDir}/..")
+def nanoiconsNodeBinary = project.findProperty("nanoicons.nodeBinary") ?: "node"
+def nanoiconsConfigPath = project.findProperty("nanoicons.configPath")
+
+ext.resolveNanoIconsCli = {
+    def stdout = new ByteArrayOutputStream()
+    exec {
+        workingDir nanoiconsProjectRoot
+        commandLine nanoiconsNodeBinary, "--print",
+            "require.resolve('react-native-nano-icons/package.json', { paths: ['${nanoiconsProjectRoot}'] })"
+        standardOutput = stdout
+    }
+    def pkgJson = new File(stdout.toString().trim())
+    return new File(pkgJson.parentFile, "lib/commonjs/scripts/cli.js")
+}
+
+tasks.register("nanoiconsGenerate") {
+    description = "Generate and stage react-native-nano-icons fonts into android assets."
+    group = "react-native-nano-icons"
+
+    doLast {
+        def cli = resolveNanoIconsCli()
+        def command = [
+            nanoiconsNodeBinary,
+            cli.absolutePath,
+            "generate",
+            "--platform", "android",
+            "--root", nanoiconsProjectRoot.absolutePath,
+        ]
+        if (nanoiconsConfigPath) {
+            command += ["--path", nanoiconsConfigPath.toString()]
+        }
+
+        exec {
+            workingDir nanoiconsProjectRoot
+            commandLine command
+        }
+    }
+}
+
+// Ensure fonts exist before Gradle assembles assets into the APK/AAB.
+tasks.matching { it.name == "preBuild" }.configureEach {
+    dependsOn "nanoiconsGenerate"
+}

--- a/packages/react-native-nano-icons/cli/build.ts
+++ b/packages/react-native-nano-icons/cli/build.ts
@@ -64,22 +64,26 @@ function shouldSkipGeneration(
 }
 
 /**
- * Build TTF + glyphmap for all icon sets using a single Pyodide/PathKit instance.
- * Output is placed in a "nanoicons" folder next to each input dir (sibling to inputDir).
- * Skips generation for a set if that output folder already contains the expected .ttf and .glyphmap.json.
+ * Build TTF + glyphmap for every icon set, reusing one Pyodide/PathKit instance.
+ * Outputs land in a sibling "nanoicons" folder and are skipped when the SVGs
+ * haven't changed.
+ *
+ * `resolveRoot` is the base for each set's relative paths (defaults to
+ * `projectRoot`); pass the config's folder so a relocated config stays portable.
  */
 export async function buildAllFonts(
   iconSets: IconSetConfig[],
   projectRoot: string,
-  options?: { logger?: NanoLogger }
+  options?: { logger?: NanoLogger; resolveRoot?: string }
 ): Promise<BuiltFont[]> {
   const logger = options?.logger;
+  const resolveRoot = options?.resolveRoot ?? projectRoot;
   const results: BuiltFont[] = [];
   let allSkipped = true;
 
   for (let i = 0; i < iconSets.length; i++) {
     const set = iconSets[i]!;
-    const inputDir = path.resolve(projectRoot, set.inputDir);
+    const inputDir = path.resolve(resolveRoot, set.inputDir);
     const fontFamily = set.fontFamily ?? path.basename(inputDir);
     const linking: 'static' | 'dynamic' = set.linking ?? 'static';
 
@@ -90,7 +94,7 @@ export async function buildAllFonts(
     }
 
     const outputDir = set.outputDir
-      ? path.resolve(projectRoot, set.outputDir)
+      ? path.resolve(resolveRoot, set.outputDir)
       : path.join(path.dirname(inputDir), 'nanoicons');
     const ttfPath = path.join(outputDir, `${fontFamily}.ttf`);
     const glyphmapPath = path.join(outputDir, `${fontFamily}.glyphmap.json`);

--- a/packages/react-native-nano-icons/cli/config.ts
+++ b/packages/react-native-nano-icons/cli/config.ts
@@ -2,35 +2,95 @@ import fs from 'node:fs';
 import path from 'node:path';
 import type { IconSetConfig } from './build.js';
 
+export const CONFIG_FILENAME = '.nanoicons.json';
+
 export type NanoIconsConfig = {
   iconSets: IconSetConfig[];
 };
 
-/**
- * Load .nanoicons.json from the given directory.
- * Throws with a helpful message if the file is missing or malformed.
- */
-export function loadNanoIconsConfig(configRoot: string): NanoIconsConfig {
-  const configPath = path.join(configRoot, '.nanoicons.json');
+export type ResolvedConfig = {
+  configPath: string;
+  /** Folder holding the config; relative inputDir/outputDir resolve against this. */
+  configRoot: string;
+};
 
-  if (!fs.existsSync(configPath)) {
-    throw new Error(
-      `🔬❌ [react-native-nano-icons] No .nanoicons.json found at (${configRoot}).\n` +
-        `Create one with: { "iconSets": [{ "inputDir": "assets/icons", "fontFamily": "MyIcons" }] } \n` +
-        `Or run with --path <dir> to specify a different directory.`
-    );
+/**
+ * Find a .nanoicons.json, even when it lives outside the project root.
+ *
+ * Uses `explicit` (a folder or a direct file path) if given, otherwise searches
+ * upward from `startDir` like git/eslint do. Build hooks (Xcode/Gradle) have an
+ * unreliable cwd, so they pass the project root as `startDir` rather than relying
+ * on process.cwd().
+ */
+export function resolveConfigPath(opts: {
+  explicit?: string;
+  startDir?: string;
+  stopAt?: string;
+}): ResolvedConfig {
+  const startDir = path.resolve(opts.startDir ?? process.cwd());
+
+  if (opts.explicit) {
+    const abs = path.resolve(startDir, opts.explicit);
+    const isDir = fs.existsSync(abs) && fs.statSync(abs).isDirectory();
+    const configPath = isDir ? path.join(abs, CONFIG_FILENAME) : abs;
+
+    if (!fs.existsSync(configPath)) {
+      throw new Error(
+        `🔬❌ [react-native-nano-icons] No ${CONFIG_FILENAME} found at (${configPath}).\n` +
+          `--path accepts either a directory containing ${CONFIG_FILENAME} or a direct path to the file.`
+      );
+    }
+
+    return { configPath, configRoot: path.dirname(configPath) };
   }
 
+  const stop = opts.stopAt
+    ? path.resolve(opts.stopAt)
+    : path.parse(startDir).root;
+  let dir = startDir;
+
+  for (;;) {
+    const configPath = path.join(dir, CONFIG_FILENAME);
+    if (fs.existsSync(configPath)) {
+      return { configPath, configRoot: dir };
+    }
+    if (dir === stop || dir === path.dirname(dir)) break;
+    dir = path.dirname(dir);
+  }
+
+  throw new Error(
+    `🔬❌ [react-native-nano-icons] Could not locate ${CONFIG_FILENAME} searching upward from (${startDir}).\n` +
+      `Create one with: { "iconSets": [{ "inputDir": "assets/icons", "fontFamily": "MyIcons" }] }\n` +
+      `Or run with --path <dir|file> to point at it.`
+  );
+}
+
+function parseConfigFile(configPath: string): NanoIconsConfig {
   const raw = fs.readFileSync(configPath, 'utf8');
   const config = JSON.parse(raw) as { iconSets?: unknown[] };
 
   if (!config?.iconSets?.length) {
     throw new Error(
-      `🔬❌ [react-native-nano-icons] .nanoicons.json must contain an "iconSets" array with at least one entry.`
+      `🔬❌ [react-native-nano-icons] ${CONFIG_FILENAME} must contain an "iconSets" array with at least one entry.`
     );
   }
 
   return config as NanoIconsConfig;
+}
+
+/** Load .nanoicons.json from a directory, with a helpful error if it's missing. */
+export function loadNanoIconsConfig(configRoot: string): NanoIconsConfig {
+  const configPath = path.join(configRoot, CONFIG_FILENAME);
+
+  if (!fs.existsSync(configPath)) {
+    throw new Error(
+      `🔬❌ [react-native-nano-icons] No ${CONFIG_FILENAME} found at (${configRoot}).\n` +
+        `Create one with: { "iconSets": [{ "inputDir": "assets/icons", "fontFamily": "MyIcons" }] } \n` +
+        `Or run with --path <dir> to specify a different directory.`
+    );
+  }
+
+  return parseConfigFile(configPath);
 }
 
 export function loadDynamicIconSets(configRoot: string): IconSetConfig[] {

--- a/packages/react-native-nano-icons/cli/index.ts
+++ b/packages/react-native-nano-icons/cli/index.ts
@@ -9,7 +9,10 @@ export {
 export {
   loadNanoIconsConfig,
   loadDynamicIconSets,
+  resolveConfigPath,
+  CONFIG_FILENAME,
   type NanoIconsConfig,
+  type ResolvedConfig,
 } from './config.js';
 export { loadDynamicSetsFromAppConfig } from './expoConfig.js';
-export { linkBare } from './link.js';
+export { linkBare, stageFonts, type Platform } from './link.js';

--- a/packages/react-native-nano-icons/cli/link.ts
+++ b/packages/react-native-nano-icons/cli/link.ts
@@ -36,10 +36,7 @@ const ANDROID_FONTS_DIR = 'android/app/src/main/assets/fonts';
 const IOS_NANOICONS_FONTS_DIR = 'nanoicons-fonts';
 const IOS_RUN_SCRIPT_PHASE_NAME = 'Copy nanoicons fonts';
 
-async function linkAndroid(
-  projectRoot: string,
-  builtFonts: BuiltFont[]
-): Promise<void> {
+function copyAndroidFonts(projectRoot: string, builtFonts: BuiltFont[]): void {
   const androidFontsPath = path.join(projectRoot, ANDROID_FONTS_DIR);
   fs.mkdirSync(androidFontsPath, { recursive: true });
 
@@ -48,6 +45,46 @@ async function linkAndroid(
     fs.copyFileSync(b.ttfPath, dest);
   }
 }
+
+/** Copy TTFs into ios/nanoicons-fonts; the build phase picks them up from there. */
+function stageIosFonts(projectRoot: string, builtFonts: BuiltFont[]): string[] {
+  const iosFontsStaging = path.join(
+    projectRoot,
+    'ios',
+    IOS_NANOICONS_FONTS_DIR
+  );
+  fs.mkdirSync(iosFontsStaging, { recursive: true });
+
+  const fontNames: string[] = [];
+  for (const b of builtFonts) {
+    const name = path.basename(b.ttfPath);
+    fontNames.push(name);
+    fs.copyFileSync(b.ttfPath, path.join(iosFontsStaging, name));
+  }
+  return fontNames;
+}
+
+/**
+ * Xcode Run Script that regenerates fonts and copies them into the app bundle on
+ * every build. Xcode build-time vars (PROJECT_DIR, BUILT_PRODUCTS_DIR) are escaped
+ * so they survive pbxproj serialization; script-local vars are plain. The config
+ * is found by searching upward from the root — set NANOICONS_CONFIG (e.g. in
+ * .xcode.env) for a config kept in a subfolder.
+ */
+const IOS_RUN_SCRIPT = `
+        set -e
+        NANOICONS_ROOT="\\\${PROJECT_DIR}/.."
+        if [ -f "\\\${PROJECT_DIR}/.xcode.env" ]; then source "\\\${PROJECT_DIR}/.xcode.env"; fi
+        if [ -f "\\\${PROJECT_DIR}/.xcode.env.local" ]; then source "\\\${PROJECT_DIR}/.xcode.env.local"; fi
+        if [ -z "$NODE_BINARY" ]; then NODE_BINARY=node; fi
+        CLI_PKG=$("$NODE_BINARY" --print "require.resolve('react-native-nano-icons/package.json', { paths: ['$NANOICONS_ROOT'] })")
+        CLI="$(dirname "$CLI_PKG")/lib/commonjs/scripts/cli.js"
+        "$NODE_BINARY" "$CLI" generate --platform ios --root "$NANOICONS_ROOT" \${NANOICONS_CONFIG:+--path "$NANOICONS_CONFIG"}
+        STAGING="$NANOICONS_ROOT/ios/${IOS_NANOICONS_FONTS_DIR}"
+        if [ -d "$STAGING" ]; then
+          cp "$STAGING"/*.ttf "\\\${BUILT_PRODUCTS_DIR}/\\\${UNLOCALIZED_RESOURCES_FOLDER_PATH}/" 2>/dev/null || true
+        fi
+      `;
 
 async function linkIos(
   projectRoot: string,
@@ -65,15 +102,7 @@ async function linkIos(
   const infoPlistPath = path.join(iosDir, appName, 'Info.plist');
   if (!fs.existsSync(infoPlistPath)) return;
 
-  const fontNames: string[] = [];
-  const iosFontsStaging = path.join(iosDir, IOS_NANOICONS_FONTS_DIR);
-  fs.mkdirSync(iosFontsStaging, { recursive: true });
-
-  for (const b of builtFonts) {
-    const name = path.basename(b.ttfPath);
-    fontNames.push(name);
-    fs.copyFileSync(b.ttfPath, path.join(iosFontsStaging, name));
-  }
+  const fontNames = stageIosFonts(projectRoot, builtFonts);
 
   const plistContent = fs.readFileSync(infoPlistPath, 'utf8');
   const obj = plist.parse(plistContent) as plist.PlistObject;
@@ -102,32 +131,59 @@ async function linkIos(
   );
 
   if (!hasPhase) {
-    const script = `
-        NANOICONS_DIR="\\\${PROJECT_DIR}/${IOS_NANOICONS_FONTS_DIR}"
-        if [ -d "$NANOICONS_DIR" ]; then
-          cp "$NANOICONS_DIR"/*.ttf "\\\${BUILT_PRODUCTS_DIR}/\\\${UNLOCALIZED_RESOURCES_FOLDER_PATH}/" 2>/dev/null || true
-        fi
-      `;
-
     project.addBuildPhase(
       [],
       'PBXShellScriptBuildPhase',
       IOS_RUN_SCRIPT_PHASE_NAME,
       project.getFirstTarget().uuid,
-      { shellPath: '/bin/sh', shellScript: script }
+      { shellPath: '/bin/sh', shellScript: IOS_RUN_SCRIPT }
     );
 
     fs.writeFileSync(pbxprojPath, project.writeSync(), 'utf8');
   }
 }
 
+export type Platform = 'ios' | 'android';
+
 /**
- * Link built TTFs into native project directories.
- *
- * Handles three cases:
- *  - Both android/ and ios/ exist → link both platforms
- *  - Only one platform dir exists → link that platform only
- *  - Neither exists (e.g. React Native Web) → skip native linking, report output dir
+ * Per-build staging called by the native hooks: copies TTFs into the platform's
+ * pickup dir without touching the Xcode project or Info.plist (that one-time
+ * wiring lives in `linkBare`). Cheap to run every build — generation is skipped
+ * when SVGs are unchanged.
+ */
+export async function stageFonts(
+  projectRoot: string,
+  builtFonts: BuiltFont[],
+  platform: Platform,
+  logger: NanoLogger
+): Promise<void> {
+  const staticFonts = builtFonts.filter((b) => b.linking === 'static');
+
+  if (!staticFonts.length) {
+    logger.info(`No static fonts to stage for ${platform}.`);
+    return;
+  }
+
+  if (platform === 'android') {
+    if (!fs.existsSync(path.join(projectRoot, 'android'))) {
+      logger.info('No android/ directory found — skipping font staging.');
+      return;
+    }
+    copyAndroidFonts(projectRoot, staticFonts);
+  } else {
+    if (!fs.existsSync(path.join(projectRoot, 'ios'))) {
+      logger.info('No ios/ directory found — skipping font staging.');
+      return;
+    }
+    stageIosFonts(projectRoot, staticFonts);
+  }
+
+  logger.succeed(`Staged ${staticFonts.length} font(s) → ${platform}`);
+}
+
+/**
+ * One-time setup: link TTFs into whichever native projects exist (android/, ios/,
+ * or neither for React Native Web).
  */
 export async function linkBare(
   projectRoot: string,
@@ -150,7 +206,7 @@ export async function linkBare(
   const hasIos = fs.existsSync(path.join(projectRoot, 'ios'));
 
   if (!hasAndroid && !hasIos) {
-    // React Native Web or other non-native target — just report where fonts landed
+    // No native dirs (e.g. React Native Web) — just report where fonts landed.
     const outputDirs = [
       ...new Set(builtFonts.map((b) => path.dirname(b.ttfPath))),
     ];
@@ -171,7 +227,7 @@ export async function linkBare(
   const linkedPlatforms: string[] = [];
 
   if (hasAndroid) {
-    await linkAndroid(projectRoot, staticFonts);
+    copyAndroidFonts(projectRoot, staticFonts);
     linkedPlatforms.push('android');
   }
 

--- a/packages/react-native-nano-icons/scripts/cli.ts
+++ b/packages/react-native-nano-icons/scripts/cli.ts
@@ -1,14 +1,19 @@
 #!/usr/bin/env node
 /**
- * Run from your app root: npx react-native-nano-icons [--verbose] [--path <dir>] [--dynamic] [--app-config]
+ * npx react-native-nano-icons [generate] [flags]   (run from your app root)
+ *
+ *   (default)   Build fonts, then link + install native build hooks. Run once.
+ *   generate    Build + stage fonts only (no project mutation). Called by the
+ *               Xcode phase / Gradle task on every build.
  *
  * Flags:
- *   --verbose          Show per-SVG processing details and pipeline timing
- *   --path <dir>       Directory containing .nanoicons.json (default: cwd)
- *   --dynamic          Rebuild only icon sets with linking: 'dynamic'. Skips native linking —
- *                      use this for OTA font regeneration without running expo prebuild.
- *   --app-config       Read config from Expo app config (app.json / app.config.js / app.config.ts)
- *                      instead of .nanoicons.json. Must be combined with --dynamic.
+ *   --verbose          Per-SVG processing and pipeline timing.
+ *   --root <dir>       Project root (default: cwd). Build hooks pass this since
+ *                      their cwd is unreliable.
+ *   --path <dir|file>  Where .nanoicons.json is. Defaults to an upward search from --root.
+ *   --platform <p>     ios | android. Required for `generate`.
+ *   --dynamic          Rebuild only linking: 'dynamic' sets (for OTA, no prebuild).
+ *   --app-config       Read sets from the Expo app config. Combine with --dynamic.
  */
 import path from 'node:path';
 import {
@@ -16,28 +21,39 @@ import {
   loadNanoIconsConfig,
   loadDynamicIconSets,
   loadDynamicSetsFromAppConfig,
+  resolveConfigPath,
   buildAllFonts,
   linkBare,
+  stageFonts,
+  type Platform,
 } from '../cli/index.js';
 
+function flagValue(name: string): string | undefined {
+  const idx = process.argv.indexOf(name);
+  return idx !== -1 ? process.argv[idx + 1] : undefined;
+}
+
 async function main(): Promise<void> {
+  const isGenerate = process.argv[2] === 'generate';
   const verbose = process.argv.includes('--verbose');
   const dynamic = process.argv.includes('--dynamic');
   const appConfig = process.argv.includes('--app-config');
   const level = verbose ? 'verbose' : 'normal';
 
-  const pathIdx = process.argv.indexOf('--path');
-  const projectRoot = process.cwd();
-  const configRoot =
-    pathIdx !== -1 && process.argv[pathIdx + 1]
-      ? path.resolve(projectRoot, process.argv[pathIdx + 1]!)
-      : projectRoot;
+  const projectRoot = flagValue('--root')
+    ? path.resolve(process.cwd(), flagValue('--root')!)
+    : process.cwd();
+  const explicitConfig = flagValue('--path');
 
   const logger = await createOraLogger(level);
 
   if (dynamic) {
     const source = appConfig ? 'Expo app config' : '.nanoicons.json';
     logger.start(`Reading dynamic icon sets from ${source}...`);
+
+    const { configRoot } = appConfig
+      ? { configRoot: projectRoot }
+      : resolveConfigPath({ explicit: explicitConfig, startDir: projectRoot });
 
     const dynamicIconSets = appConfig
       ? loadDynamicSetsFromAppConfig(projectRoot)
@@ -47,13 +63,35 @@ async function main(): Promise<void> {
       `Found ${dynamicIconSets.length} dynamic icon set(s) — skipping native linking.`
     );
 
-    await buildAllFonts(dynamicIconSets, projectRoot, { logger });
-  } else {
-    const config = loadNanoIconsConfig(configRoot);
-    const built = await buildAllFonts(config.iconSets, projectRoot, { logger });
-
-    await linkBare(projectRoot, built, logger);
+    await buildAllFonts(dynamicIconSets, projectRoot, {
+      logger,
+      resolveRoot: configRoot,
+    });
+    return;
   }
+
+  const { configRoot } = resolveConfigPath({
+    explicit: explicitConfig,
+    startDir: projectRoot,
+  });
+  const config = loadNanoIconsConfig(configRoot);
+  const built = await buildAllFonts(config.iconSets, projectRoot, {
+    logger,
+    resolveRoot: configRoot,
+  });
+
+  if (isGenerate) {
+    const platform = flagValue('--platform') as Platform | undefined;
+    if (platform !== 'ios' && platform !== 'android') {
+      throw new Error(
+        `[react-native-nano-icons] generate requires --platform ios|android.`
+      );
+    }
+    await stageFonts(projectRoot, built, platform, logger);
+    return;
+  }
+
+  await linkBare(projectRoot, built, logger);
 }
 
 main().catch((err: unknown) => {


### PR DESCRIPTION
## Description
This lib supports both build (svg -> ttf) and linking step. Unfortunatelly, for non expo apps you have to manually trigger those actions. This PR solves this.
I had a quandary when approaching the '.nanoicons file can be places anywhere' issue. I decided the most efficient way to resolve it is to search by walking upward from a build folder (just like git solves this).

For android we introduce new gradle script (nanoicons.gradle) that registers a task which calls scripts/cli.ts. For ios we inject IOS_ RUN_SCRIPT into the xcode project. Expo apps are unaffected by this change, as they do not use scripts/cli.ts anyway
<!--
Description and motivation for this PR.

Include 'Fixes #<number>' if this is fixing some issue.
-->

## Test plan
Unit tests, manual testing. I also linked gradle task to our example app.
<!--
Describe how did you test this change here.
-->
