### PR TITLE
fix: embedded baseline OTA .ttf not loading

### DIFF
--- a/packages/react-native-nano-icons/android/src/main/java/com/nanoicons/NanoIconsFontLoaderModule.kt
+++ b/packages/react-native-nano-icons/android/src/main/java/com/nanoicons/NanoIconsFontLoaderModule.kt
@@ -49,7 +49,12 @@ class NanoIconsFontLoaderModule(reactContext: ReactApplicationContext) :
       uri.startsWith("file://") ||
         uri.startsWith("http://") ||
         uri.startsWith("https://") -> URL(uri).openStream()
-      else -> File(uri).inputStream()
+      else -> {
+        val resources = reactApplicationContext.resources
+        val resId =
+          resources.getIdentifier(uri, "raw", reactApplicationContext.packageName)
+        if (resId != 0) resources.openRawResource(resId) else File(uri).inputStream()
+      }
     }
 
   companion object {


### PR DESCRIPTION
## Description

For the initial build of OTA app, we need to provide the baseline of the font. When building app in mode release, this baseline struggled to be loaded, because it neither is a file per se nor lives on the filesystem. We fix this, by providing loader with resource id instead of path/name, so the font gets resolved correctly
<!--
Description and motivation for this PR.

Include 'Fixes #<number>' if this is fixing some issue.
-->

## Test plan
Unit tests can't really catch this, manual testing only
<!--
Describe how did you test this change here.
-->
