### PR TITLE
fix: no react-native export field

### DIFF
--- a/packages/react-native-nano-icons/package.json
+++ b/packages/react-native-nano-icons/package.json
@@ -83,7 +83,7 @@
   },
   "exports": {
     ".": {
-      "source": "./src/index.tsx",
+      "source": "./src/index.ts",
       "react-native": "./lib/module/index.js",
       "require": {
         "types": "./lib/typescript/src/index.d.ts",

--- a/packages/react-native-nano-icons/package.json
+++ b/packages/react-native-nano-icons/package.json
@@ -84,6 +84,7 @@
   "exports": {
     ".": {
       "source": "./src/index.tsx",
+      "react-native": "./lib/module/index.js",
       "require": {
         "types": "./lib/typescript/src/index.d.ts",
         "default": "./lib/commonjs/index.node.js"


### PR DESCRIPTION
## Description
Exports lacked `react-native`, so Metro resolved the package wrongly.  

Only surfaced for consumers installing from npm, monorepo examples were unaffected because symlinks let Metro
fall back to the legacy top-level `react-native` field.
<!--
Description and motivation for this PR.

Include 'Fixes #<number>' if this is fixing some issue.
-->

## Test plan

<!--
Describe how did you test this change here.
-->

