### PR TITLE
feat: introduced className for Web

### DIFF
--- a/packages/react-native-nano-icons/src/createNanoIconsSet.web.tsx
+++ b/packages/react-native-nano-icons/src/createNanoIconsSet.web.tsx
@@ -31,6 +31,7 @@ export function createIconSet<GM extends NanoGlyphMapInput>(
       accessibilityRole = 'image',
       accessibilityElementsHidden,
       testID,
+      className,
       ref,
     }: IconProps<keyof GM['i']>) => {
       const [adv, layers] = resolveGlyphEntry(glyphMap, name);
@@ -72,6 +73,7 @@ export function createIconSet<GM extends NanoGlyphMapInput>(
       return (
         <span
           ref={ref as React.Ref<HTMLSpanElement>}
+          className={className}
           style={containerStyle}
           role={isHidden ? undefined : role}
           aria-label={
@@ -97,6 +99,7 @@ export function createIconSet<GM extends NanoGlyphMapInput>(
       prev.name === next.name &&
       prev.size === next.size &&
       prev.style === next.style &&
+      prev.className === next.className &&
       shallowEqualColor(prev.color, next.color)
   );
 

--- a/packages/react-native-nano-icons/src/types.ts
+++ b/packages/react-native-nano-icons/src/types.ts
@@ -22,6 +22,11 @@ export type IconProps<Name> = {
   importantForAccessibility?: 'auto' | 'yes' | 'no' | 'no-hide-descendants'; // Android
   ref?: Ref<ViewRef>;
   testID?: string;
+  /**
+   * Forwarded to the container element on web (e.g. for Tailwind/Uniwind).
+   * @platform Web only - no-op on native.
+   */
+  className?: string;
 };
 
 export type IconComponent<GM extends NanoGlyphMapInput> = React.FC<

--- a/packages/react-native-nano-icons/src/types.ts
+++ b/packages/react-native-nano-icons/src/types.ts
@@ -23,7 +23,7 @@ export type IconProps<Name> = {
   ref?: Ref<ViewRef>;
   testID?: string;
   /**
-   * Forwarded to the container element on web (e.g. for Tailwind/Uniwind).
+   * Forwarded to the container element on web.
    * @platform Web only - no-op on native.
    */
   className?: string;


### PR DESCRIPTION
## Description
Introducing className prop for web, so users can forward tailwind classes directly.   
This change modified mutual IconProps type, so technically this change influences native implementation as well. This being said, for simplicity and convenience sake we decided against separate types and just added no-op comment.
<!--
Description and motivation for this PR.

Include 'Fixes #<number>' if this is fixing some issue.
-->

## Test plan
Manual testing, class is being passed
<img width="282" height="27" alt="image" src="https://github.com/user-attachments/assets/764be20a-aea3-448b-839f-f22a963e8f99" />

<!--
Describe how did you test this change here.
-->
