### PR TITLE
fix(ios): stale glyph scale and state leaks on recycled icon views

### DIFF
--- a/packages/react-native-nano-icons/ios/NanoIconView.mm
+++ b/packages/react-native-nano-icons/ios/NanoIconView.mm
@@ -186,6 +186,9 @@ void NanoIconInvalidateFontCache(NSString *family) {
   NanoIconDrawingLayer *layer = [NanoIconDrawingLayer layer];
   layer.owner = self;
   layer.opaque = NO;
+  // Without this, a resize stretches the stale pixel buffer instead of
+  // redrawing at the recomputed _fitScale.
+  layer.needsDisplayOnBoundsChange = YES;
   layer.contentsScale = [UIScreen mainScreen].scale;
   [self.layer addSublayer:layer];
   _drawingLayer = layer;
@@ -204,10 +207,14 @@ void NanoIconInvalidateFontCache(NSString *family) {
   }
 }
 
-// Invalidate cached offset when size changes (text relayout).
+// Invalidate size-derived state when size changes (text relayout, Yoga
+// relayout, view recycling). _fitScale is computed from bounds.height, so
+// metrics must be recomputed on the next layout pass or the glyph is drawn
+// at the previous bounds' scale (overflowing or underfilling the new box).
 - (void)setBounds:(CGRect)bounds {
   if (!CGSizeEqualToSize(self.bounds.size, bounds.size)) {
     _baselineOffsetValid = NO;
+    _metricsValid = NO;
   }
   [super setBounds:bounds];
 }
@@ -403,6 +410,51 @@ void NanoIconInvalidateFontCache(NSString *family) {
       [self setNeedsDisplay];
     }
   }
+}
+
+#pragma mark - Recycling
+
+// Fabric recycles component views, so state that outlives a mount has to be
+// cleared here. Deliberately left alone:
+//
+//   - `_props`. Both `updateProps:` implementations diff against `*_props`,
+//     not against the `oldProps` argument (which is `nullptr` on a fresh
+//     mount). Resetting it to defaults makes every prop the next icon leaves
+//     at its default value compare equal and never get re-applied, so the
+//     recycled view keeps the previous mount's state — a `transform` still
+//     on the layer, a stale `opacity`, `pointerEvents`, `hitSlop`… No RN
+//     component view resets `_props` on recycle for that reason;
+//     `RCTScrollViewComponentView` even reads `*_props` in its own
+//     `prepareForRecycle`. The concrete default belongs in the initializer,
+//     which is where we set it.
+//   - `_font`, `_fontFamily`, `_fontSize`, `_glyphs`, `_colors` and the
+//     cached `CGColorRef`s. They all derive from `_props`, so they stay
+//     coherent with it as long as it is left in place, and `updateProps:`
+//     recomputes each of them on its own prop change. (`_rebuildCachedColors`
+//     releases the previous refs, `dealloc` releases the last ones.)
+//
+// `_fitScale` and `_baselinePosition` are size-derived, not prop-derived:
+// invalidating `_metricsValid` is what forces them to be recomputed against
+// the new bounds before the next draw.
+- (void)prepareForRecycle {
+  [super prepareForRecycle];
+
+  _metricsValid = NO;
+
+  _inlineDetected = NO;
+  _isInlineInText = NO;
+  _paragraphView = nil;
+  _cachedBaselineOffset = 0;
+  _baselineOffsetValid = NO;
+  if (_drawingLayer) {
+    [_drawingLayer removeFromSuperlayer];
+    _drawingLayer = nil;
+  }
+
+  // The previous mount may have drawn into `_drawingLayer` rather than into
+  // `self`, and an icon recycled with identical props produces no redraw from
+  // `updateProps:`. Mark the view dirty so the next mount always repaints.
+  [self setNeedsDisplay];
 }
 
 - (void)dealloc {

--- a/packages/react-native-nano-icons/ios/NanoIconView.mm
+++ b/packages/react-native-nano-icons/ios/NanoIconView.mm
@@ -186,8 +186,6 @@ void NanoIconInvalidateFontCache(NSString *family) {
   NanoIconDrawingLayer *layer = [NanoIconDrawingLayer layer];
   layer.owner = self;
   layer.opaque = NO;
-  // Without this, a resize stretches the stale pixel buffer instead of
-  // redrawing at the recomputed _fitScale.
   layer.needsDisplayOnBoundsChange = YES;
   layer.contentsScale = [UIScreen mainScreen].scale;
   [self.layer addSublayer:layer];
@@ -207,10 +205,7 @@ void NanoIconInvalidateFontCache(NSString *family) {
   }
 }
 
-// Invalidate size-derived state when size changes (text relayout, Yoga
-// relayout, view recycling). _fitScale is computed from bounds.height, so
-// metrics must be recomputed on the next layout pass or the glyph is drawn
-// at the previous bounds' scale (overflowing or underfilling the new box).
+// _cachedBaselineOffset and _fitScale are both derived from bounds.
 - (void)setBounds:(CGRect)bounds {
   if (!CGSizeEqualToSize(self.bounds.size, bounds.size)) {
     _baselineOffsetValid = NO;
@@ -410,51 +405,6 @@ void NanoIconInvalidateFontCache(NSString *family) {
       [self setNeedsDisplay];
     }
   }
-}
-
-#pragma mark - Recycling
-
-// Fabric recycles component views, so state that outlives a mount has to be
-// cleared here. Deliberately left alone:
-//
-//   - `_props`. Both `updateProps:` implementations diff against `*_props`,
-//     not against the `oldProps` argument (which is `nullptr` on a fresh
-//     mount). Resetting it to defaults makes every prop the next icon leaves
-//     at its default value compare equal and never get re-applied, so the
-//     recycled view keeps the previous mount's state — a `transform` still
-//     on the layer, a stale `opacity`, `pointerEvents`, `hitSlop`… No RN
-//     component view resets `_props` on recycle for that reason;
-//     `RCTScrollViewComponentView` even reads `*_props` in its own
-//     `prepareForRecycle`. The concrete default belongs in the initializer,
-//     which is where we set it.
-//   - `_font`, `_fontFamily`, `_fontSize`, `_glyphs`, `_colors` and the
-//     cached `CGColorRef`s. They all derive from `_props`, so they stay
-//     coherent with it as long as it is left in place, and `updateProps:`
-//     recomputes each of them on its own prop change. (`_rebuildCachedColors`
-//     releases the previous refs, `dealloc` releases the last ones.)
-//
-// `_fitScale` and `_baselinePosition` are size-derived, not prop-derived:
-// invalidating `_metricsValid` is what forces them to be recomputed against
-// the new bounds before the next draw.
-- (void)prepareForRecycle {
-  [super prepareForRecycle];
-
-  _metricsValid = NO;
-
-  _inlineDetected = NO;
-  _isInlineInText = NO;
-  _paragraphView = nil;
-  _cachedBaselineOffset = 0;
-  _baselineOffsetValid = NO;
-  if (_drawingLayer) {
-    [_drawingLayer removeFromSuperlayer];
-    _drawingLayer = nil;
-  }
-
-  // The previous mount may have drawn into `_drawingLayer` rather than into
-  // `self`, and an icon recycled with identical props produces no redraw from
-  // `updateProps:`. Mark the view dirty so the next mount always repaints.
-  [self setNeedsDisplay];
 }
 
 - (void)dealloc {


### PR DESCRIPTION
fixes: https://github.com/software-mansion-labs/react-native-nano-icons/issues/46

Related: #12, #18

## Description

On iOS (Fabric), icons could randomly render larger than requested and get clipped, and icons with `allowFontScaling={false}` could randomly pick up the system font scale. Both symptoms trace back to size-derived drawing state (`_fitScale`) surviving bounds changes and view recycling. This PR fixes three independent defects in `NanoIconView.mm`.

## Changes

### 1. Invalidate `_metricsValid` in `setBounds:` when the size changes

`_fitScale` is computed from `bounds.size.height` and cached behind `_metricsValid`. Previously only the inline-text baseline offset was invalidated on resize, so any view whose height changed after its first layout kept redrawing at the previous bounds' scale (`contentMode = Redraw` forces the redraw, but with stale metrics). Bounds shrinking → glyph overflows the backing store → clipped.

### 2. Add a `prepareForRecycle` override

Fabric recycles component views by default, and nothing in the base class clears the icon-specific state that outlives a mount: the inline-in-`<Text>` detection (`_inlineDetected` / `_isInlineInText` / `_paragraphView`), its lazily created `_drawingLayer`, the cached baseline offset, and `_metricsValid`. The override resets exactly that, and marks the view dirty — the previous mount may have drawn into `_drawingLayer` rather than into `self`, and an icon recycled with identical props produces no redraw from `updateProps:`.

This is the same root mechanism as #12 (blank / overlapping icons after navigation): state surviving Fabric view reuse. #18 fixed the inline-in-Text part of it in `didMoveToSuperview`; this change covers the remaining leaked state at the right lifecycle point.

Invalidating `_metricsValid` here is also what makes the reported bug deterministic again: a view previously laid out with font-scaled bounds could be recycled for an icon with the same `fontSize` prop but unscaled bounds — nothing invalidated the metrics, so the glyph was drawn with the scaled `_fitScale` inside the unscaled box, which looks exactly like `allowFontScaling={false}` being ignored.

**What `prepareForRecycle` deliberately does not touch — and why it matters:**

- **`_props`.** Both `RCTViewComponentView`'s `updateProps:` and ours diff against `*_props`, not against the `oldProps` argument (which is `nullptr` on a fresh mount). Resetting `_props` to a default instance therefore makes every prop the *next* icon leaves at its default value compare equal to the incoming props and never get re-applied, so the recycled view silently keeps the previous mount's state: a `transform` still sitting on the `CALayer` (a `rotate(90deg)` chevron leaving the next icon on its side), a stale `opacity`, `pointerEvents`, `hitSlop`, `overflow`… `updateLayoutMetrics:` does not recover it either, since it only recomputes the transform when `_props->transform` is non-empty. No RN component view resets `_props` on recycle for exactly this reason — `RCTScrollViewComponentView` even reads `*_props` inside its own `prepareForRecycle`. The concrete `NanoIconViewProps` default belongs in the initializer, which is where we already set it.
- **`_font`, `_fontFamily`, `_fontSize`, `_glyphs`, `_colors` and the cached `CGColorRef`s.** They all derive from `_props`, so leaving `_props` in place keeps them coherent with it, and `updateProps:` recomputes each of them on its own prop change. `_rebuildCachedColors` releases the previous refs and `dealloc` releases the last ones, so nothing leaks.

`_fitScale` and `_baselinePosition` are the exception: they are size-derived rather than prop-derived, which is why `_metricsValid = NO` is the thing that has to be reset here.

### 3. Set `needsDisplayOnBoundsChange` on the inline drawing sublayer

The lazily created `NanoIconDrawingLayer` (used for icons inline in `<Text>`) only received a `setNeedsDisplay` at creation time. On resize its frame was updated but the stale pixel buffer was stretched instead of repainted. With change (1) the correct `_fitScale` is now recomputed on resize; this flag makes the layer actually repaint with it.

## Test plan

- [ ] iOS system Text Size above default, screen mixing icons with the same `size` but different `allowFontScaling` values: all render at their expected size.
- [ ] Navigate away and back repeatedly (mount/unmount → view recycling): no icon renders clipped, at the wrong scale, or with another icon's glyph/colors.
- [ ] A screen mixing icons with `style={{ transform: [{ rotate: '90deg' }] }}` and icons without any transform, scrolled / re-mounted enough to force recycling: no icon inherits the previous one's rotation.
- [ ] Icons inline in `<Text>`: resize (e.g. font scale or `size` change) repaints correctly instead of stretching.
- [ ] No regression on the standalone (non-inline) rendering path at default font scale.
