### PR TITLE
fix(android): fit glyph to view bounds so font scale applies

### DIFF
--- a/packages/react-native-nano-icons/android/src/main/java/com/nanoicons/NanoIconView.kt
+++ b/packages/react-native-nano-icons/android/src/main/java/com/nanoicons/NanoIconView.kt
@@ -19,6 +19,9 @@ class NanoIconView(context: Context) : View(context) {
   private var cachedTexts: Array<String> = emptyArray()
   // Cached baseline — rebuilt when font, size, or bounds change
   private var cachedBaseline: Float = 0f
+  // Derived from the loaded font's metrics; recomputed on typeface change.
+  private var textSizeFactor = 0f
+  private var baselineFactor = 0f
 
   init {
     // Transparent background, no default drawing
@@ -31,18 +34,18 @@ class NanoIconView(context: Context) : View(context) {
       cachedTypeface = ReactFontManager.getInstance()
         .getTypeface(fontFamily, Typeface.NORMAL, context.assets)
       paint.typeface = cachedTypeface
-      fitPaintToBounds()
+      updateFontFactors()
+      fitToBounds()
       invalidate()
     }
   }
 
   fun setFontSize(size: Float) {
-    val sizeInPx = size * resources.displayMetrics.density
-    if (paint.textSize != sizeInPx) {
-      paint.textSize = sizeInPx
-      fitPaintToBounds()
-      invalidate()
-    }
+    // Only seeds a size for use before the first layout; bounds win after that.
+    paint.textSize = size * resources.displayMetrics.density
+    if (textSizeFactor <= 0f) updateFontFactors()
+    fitToBounds()
+    invalidate()
   }
 
   fun setCodepoints(values: IntArray) {
@@ -58,25 +61,27 @@ class NanoIconView(context: Context) : View(context) {
 
   override fun onSizeChanged(w: Int, h: Int, oldw: Int, oldh: Int) {
     super.onSizeChanged(w, h, oldw, oldh)
-    fitPaintToBounds()
+    fitToBounds()
     invalidate()
   }
 
-  // Scale the glyph em square to fill the view height (mirrors iOS _fitScale).
-  // The view bounds — not the fontSize prop — carry the resolved size: JS sizes
-  // the box to size * fontScale while the fontSize prop is the unscaled size,
-  // so fitting to bounds is what applies allowFontScaling to the drawn glyph.
-  private fun fitPaintToBounds() {
-    val h = height.toFloat()
-    if (h <= 0f || paint.textSize <= 0f) return
+  private fun updateFontFactors() {
+    val ts = paint.textSize
+    if (cachedTypeface == null || ts <= 0f) return
     paint.getFontMetrics(fontMetrics)
-    val em = fontMetrics.descent - fontMetrics.ascent
-    if (em > 0f) {
-      paint.textSize = paint.textSize * h / em
-      paint.getFontMetrics(fontMetrics)
-    }
-    // Bottom-anchor the baseline like iOS so ascent + descent spans the box.
-    cachedBaseline = h - fontMetrics.descent
+    val band = fontMetrics.descent - fontMetrics.ascent
+    if (band <= 0f) return
+    textSizeFactor = ts / band
+    baselineFactor = 1f - fontMetrics.descent / band
+  }
+
+  // Font scale is derived from the bounds, not from the fontSize prop.
+  private fun fitToBounds() {
+    val h = height.toFloat()
+    if (h <= 0f || textSizeFactor <= 0f) return
+    cachedBaseline = h * baselineFactor
+    val size = h * textSizeFactor
+    if (paint.textSize != size) paint.textSize = size
   }
 
   override fun onDraw(canvas: Canvas) {

--- a/packages/react-native-nano-icons/android/src/main/java/com/nanoicons/NanoIconView.kt
+++ b/packages/react-native-nano-icons/android/src/main/java/com/nanoicons/NanoIconView.kt
@@ -10,13 +10,14 @@ import com.facebook.react.common.assets.ReactFontManager
 class NanoIconView(context: Context) : View(context) {
 
   private val paint = Paint(Paint.ANTI_ALIAS_FLAG)
+  private val fontMetrics = Paint.FontMetrics()
   private var codepoints: IntArray = intArrayOf()
   private var colors: IntArray = intArrayOf()
   private var cachedFontFamily: String? = null
   private var cachedTypeface: Typeface? = null
   // Cached String objects — rebuilt only when codepoints change
   private var cachedTexts: Array<String> = emptyArray()
-  // Cached baseline — rebuilt only when font or size changes
+  // Cached baseline — rebuilt when font, size, or bounds change
   private var cachedBaseline: Float = 0f
 
   init {
@@ -30,7 +31,7 @@ class NanoIconView(context: Context) : View(context) {
       cachedTypeface = ReactFontManager.getInstance()
         .getTypeface(fontFamily, Typeface.NORMAL, context.assets)
       paint.typeface = cachedTypeface
-      updateBaseline()
+      fitPaintToBounds()
       invalidate()
     }
   }
@@ -39,7 +40,7 @@ class NanoIconView(context: Context) : View(context) {
     val sizeInPx = size * resources.displayMetrics.density
     if (paint.textSize != sizeInPx) {
       paint.textSize = sizeInPx
-      updateBaseline()
+      fitPaintToBounds()
       invalidate()
     }
   }
@@ -55,8 +56,27 @@ class NanoIconView(context: Context) : View(context) {
     invalidate()
   }
 
-  private fun updateBaseline() {
-    cachedBaseline = -paint.fontMetrics.ascent
+  override fun onSizeChanged(w: Int, h: Int, oldw: Int, oldh: Int) {
+    super.onSizeChanged(w, h, oldw, oldh)
+    fitPaintToBounds()
+    invalidate()
+  }
+
+  // Scale the glyph em square to fill the view height (mirrors iOS _fitScale).
+  // The view bounds — not the fontSize prop — carry the resolved size: JS sizes
+  // the box to size * fontScale while the fontSize prop is the unscaled size,
+  // so fitting to bounds is what applies allowFontScaling to the drawn glyph.
+  private fun fitPaintToBounds() {
+    val h = height.toFloat()
+    if (h <= 0f || paint.textSize <= 0f) return
+    paint.getFontMetrics(fontMetrics)
+    val em = fontMetrics.descent - fontMetrics.ascent
+    if (em > 0f) {
+      paint.textSize = paint.textSize * h / em
+      paint.getFontMetrics(fontMetrics)
+    }
+    // Bottom-anchor the baseline like iOS so ascent + descent spans the box.
+    cachedBaseline = h - fontMetrics.descent
   }
 
   override fun onDraw(canvas: Canvas) {


### PR DESCRIPTION
fixes: https://github.com/software-mansion-labs/react-native-nano-icons/issues/48
Related: https://github.com/software-mansion-labs/react-native-nano-icons/pull/47

## Description

On Android, `allowFontScaling` was only applied to the icon's layout box, never to the drawn glyph. JS sizes the view to `size * fontScale`, but the native view drew the glyph at `fontSize * density` px — and the `fontSize` prop is the unscaled `size`. iOS compensates by fitting the glyph's em square to the view bounds (`_fitScale`); Android had no equivalent. Result: with a system font scale > 1, icons rendered too small and misaligned with text; with a font scale < 1, they were cropped by the `clipRect` in `onDraw`.

<!--
Description and motivation for this PR.

Include 'Fixes #<number>' if this is fixing some issue.
-->

## Changes

### 1. New `fitPaintToBounds()`

Scales `paint.textSize` so that `ascent + descent` spans the view height, mirroring the iOS `_fitScale`. The view bounds — which carry the resolved size including `fontScale` — become the single source of truth for the rendered glyph size, exactly as on iOS.

### 2. Refit on `onSizeChanged`

Any resize (font scale change, `size` change, relayout) now redraws at the correct scale instead of keeping the stale `textSize`.

### 3. Bottom-anchored baseline

`cachedBaseline` is now `height - descent` instead of `-ascent` (top-anchored), matching the iOS convention. The glyph fills the box, which fixes the vertical misalignment with adjacent text when the box was taller than the glyph.

### 4. `setFontFamily` / `setFontSize` refit instead of only recomputing the baseline

Width consistency is preserved by construction: a glyph fitted to `height` px has an advance of `(adv / upm) * height`, which is exactly the box width computed on the JS side (`(adv / upm) * size * fontScale`).

## Test plan

<!--
Describe how did you test this change here.
-->

- [ ] Android system font size above default, icons next to text with default `allowFontScaling`: icons scale with the text and are vertically aligned.
- [ ] System font size below default: no cropping.
- [ ] `allowFontScaling={false}` icons: unchanged (unscaled) at any system font size.
- [ ] Default font scale (1.0): no visual regression — glyph fits the box exactly as before.
- [ ] Mixed screen (`allowFontScaling` true/false, various `size` values): every icon matches its requested size.