### PR TITLE
fix(cli): resolve iOS Info.plist from target build settings

### DIFF
--- a/packages/react-native-nano-icons/__tests__/link.unit.test.ts
+++ b/packages/react-native-nano-icons/__tests__/link.unit.test.ts
@@ -5,16 +5,18 @@ import os from 'node:os';
 import path from 'node:path';
 import * as plist from 'plist';
 
+const mockXcodeProject = {
+  parseSync() {
+    return this;
+  },
+  getFirstTarget: () => ({ uuid: 'fake-target-uuid' }),
+  addBuildPhase: () => {},
+  writeSync: () => '// fake pbxproj',
+  hash: { project: { objects: {} as Record<string, unknown> } },
+};
+
 jest.mock('xcode', () => ({
-  project: () => ({
-    parseSync() {
-      return this;
-    },
-    getFirstTarget: () => ({ uuid: 'fake-target-uuid' }),
-    addBuildPhase: () => {},
-    writeSync: () => '// fake pbxproj',
-    hash: { project: { objects: {} } },
-  }),
+  project: () => mockXcodeProject,
 }));
 
 import { linkBare } from '../cli/link';
@@ -22,6 +24,10 @@ import type { NanoLogger } from '../cli/logger';
 import type { BuiltFont } from '../cli/build';
 
 const MINIMAL_PLIST = plist.build({ CFBundleName: 'placeholder' });
+
+beforeEach(() => {
+  mockXcodeProject.hash.project.objects = {};
+});
 
 function makeTmpDir(): string {
   return fs.mkdtempSync(path.join(os.tmpdir(), 'nano-link-'));
@@ -85,7 +91,7 @@ describe('linkBare — iOS Info.plist target selection', () => {
     fs.rmSync(fontDir, { recursive: true, force: true });
   });
 
-  test('updates the main app Info.plist, not the alphabetically-first sibling', async () => {
+  test('uses the conventional Info.plist path as a fallback, not the alphabetically-first sibling', async () => {
     const builtFont: BuiltFont = {
       fontFamily: 'TestFont',
       ttfPath: path.join(fontDir, 'TestFont.ttf'),
@@ -106,6 +112,75 @@ describe('linkBare — iOS Info.plist target selection', () => {
     expect(readUIAppFonts(mainPlist)).toContain('TestFont.ttf');
     expect(readUIAppFonts(decoyPlist)).not.toContain('TestFont.ttf');
     expect(readUIAppFonts(decoyPlist)).toEqual([]);
+  });
+
+  test('uses INFOPLIST_FILE from the first app target build configuration', async () => {
+    const conventionalPlist = path.join(
+      projectRoot,
+      'ios',
+      'MyApp',
+      'Info.plist'
+    );
+    fs.rmSync(conventionalPlist);
+    const debugPlist = path.join(
+      projectRoot,
+      'ios',
+      'Resources',
+      'Debug-Info.plist'
+    );
+    const releasePlist = path.join(
+      projectRoot,
+      'ios',
+      'Resources',
+      'Release-Info.plist'
+    );
+    fs.mkdirSync(path.dirname(debugPlist));
+    fs.writeFileSync(debugPlist, MINIMAL_PLIST);
+    fs.writeFileSync(releasePlist, MINIMAL_PLIST);
+
+    mockXcodeProject.hash.project.objects = {
+      PBXNativeTarget: {
+        APP_TARGET: {
+          productType: '"com.apple.product-type.application"',
+          buildConfigurationList: 'APP_CONFIGURATIONS',
+        },
+      },
+      XCConfigurationList: {
+        APP_CONFIGURATIONS: {
+          buildConfigurations: [
+            { value: 'DEBUG_CONFIGURATION' },
+            { value: 'RELEASE_CONFIGURATION' },
+          ],
+        },
+      },
+      XCBuildConfiguration: {
+        DEBUG_CONFIGURATION: {
+          buildSettings: { INFOPLIST_FILE: 'Resources/Debug-Info.plist' },
+        },
+        RELEASE_CONFIGURATION: {
+          buildSettings: {
+            INFOPLIST_FILE: '$(SRCROOT)/Resources/Release-Info.plist',
+          },
+        },
+      },
+    };
+
+    const builtFont: BuiltFont = {
+      fontFamily: 'TestFont',
+      ttfPath: path.join(fontDir, 'TestFont.ttf'),
+      glyphmapPath: path.join(fontDir, 'TestFont.glyphmap.json'),
+      linking: 'static',
+    };
+
+    await linkBare(projectRoot, [builtFont], makeLogger());
+
+    expect(readUIAppFonts(debugPlist)).toContain('TestFont.ttf');
+    expect(readUIAppFonts(releasePlist)).toContain('TestFont.ttf');
+    expect(
+      readUIAppFonts(
+        path.join(projectRoot, 'ios', 'AppExtension', 'Info.plist')
+      )
+    ).toEqual([]);
   });
 });
 
@@ -308,6 +383,23 @@ describe('linkBare - platform detection & edge cases', () => {
     expect(
       fs.existsSync(path.join(projectRoot, IOS_STAGING_DIR, 'StagedFont.ttf'))
     ).toBe(true);
+  });
+
+  test('does not report iOS as linked when no Info.plist can be resolved', async () => {
+    const iosDir = path.join(projectRoot, 'ios');
+    fs.mkdirSync(path.join(iosDir, 'MyApp.xcodeproj'), { recursive: true });
+    fs.writeFileSync(
+      path.join(iosDir, 'MyApp.xcodeproj', 'project.pbxproj'),
+      '// fake pbxproj'
+    );
+    const logger = makeLogger();
+
+    await linkBare(projectRoot, [builtFont('UnlinkedIos')], logger);
+
+    expect(fs.existsSync(path.join(projectRoot, IOS_STAGING_DIR))).toBe(false);
+    expect(logger.succeed).toHaveBeenCalledWith(
+      expect.not.stringContaining('ios')
+    );
   });
 
   test('UIAppFonts merges with pre-existing entries without clobbering them', async () => {

--- a/packages/react-native-nano-icons/__tests__/link.unit.test.ts
+++ b/packages/react-native-nano-icons/__tests__/link.unit.test.ts
@@ -5,14 +5,48 @@ import os from 'node:os';
 import path from 'node:path';
 import * as plist from 'plist';
 
+const APP_TARGET_UUID = 'APP_TARGET';
+const FIRST_TARGET_UUID = 'FIRST_TARGET';
+const CONFIGURATION_LIST_UUID = 'APP_CONFIGURATION_LIST';
+
+type MockTarget = { name: string; buildConfigurationList: string };
+
+const mockPbxproj = {
+  appTarget: null as { uuid: string; target: MockTarget } | null,
+  firstTarget: { uuid: FIRST_TARGET_UUID, firstTarget: {} as MockTarget },
+  configurationLists: {} as Record<string, { buildConfigurations: unknown[] }>,
+  buildConfigurations: {} as Record<
+    string,
+    { buildSettings: Record<string, string> }
+  >,
+  objects: {} as Record<string, unknown>,
+  addedBuildPhaseTargets: [] as (string | undefined)[],
+};
+
 const mockXcodeProject = {
   parseSync() {
     return this;
   },
-  getFirstTarget: () => ({ uuid: 'fake-target-uuid' }),
-  addBuildPhase: () => {},
+  getTarget: () => mockPbxproj.appTarget,
+  getFirstTarget: () => mockPbxproj.firstTarget,
+  pbxXCConfigurationList: () => mockPbxproj.configurationLists,
+  pbxXCBuildConfigurationSection: () => mockPbxproj.buildConfigurations,
+  addBuildPhase: (
+    _files: string[],
+    _phaseType: string,
+    _comment: string,
+    target?: string
+  ) => {
+    mockPbxproj.addedBuildPhaseTargets.push(target);
+  },
   writeSync: () => '// fake pbxproj',
-  hash: { project: { objects: {} as Record<string, unknown> } },
+  hash: {
+    project: {
+      get objects() {
+        return mockPbxproj.objects;
+      },
+    },
+  },
 };
 
 jest.mock('xcode', () => ({
@@ -25,8 +59,46 @@ import type { BuiltFont } from '../cli/build';
 
 const MINIMAL_PLIST = plist.build({ CFBundleName: 'placeholder' });
 
+function setInfoPlistFiles(
+  infoPlistFiles: string[],
+  { resolvableAppTarget = true }: { resolvableAppTarget?: boolean } = {}
+): void {
+  const uuids = infoPlistFiles.map((_, index) => `CONFIGURATION_${index}`);
+  const target: MockTarget = {
+    name: 'MyApp',
+    buildConfigurationList: CONFIGURATION_LIST_UUID,
+  };
+
+  if (resolvableAppTarget) {
+    mockPbxproj.appTarget = { uuid: APP_TARGET_UUID, target };
+  } else {
+    mockPbxproj.appTarget = null;
+    mockPbxproj.firstTarget = { uuid: FIRST_TARGET_UUID, firstTarget: target };
+  }
+
+  mockPbxproj.configurationLists = {
+    [CONFIGURATION_LIST_UUID]: {
+      buildConfigurations: uuids.map((value) => ({ value })),
+    },
+  };
+  mockPbxproj.buildConfigurations = Object.fromEntries(
+    uuids.map((uuid, index) => [
+      uuid,
+      { buildSettings: { INFOPLIST_FILE: infoPlistFiles[index]! } },
+    ])
+  );
+}
+
 beforeEach(() => {
-  mockXcodeProject.hash.project.objects = {};
+  mockPbxproj.appTarget = null;
+  mockPbxproj.firstTarget = {
+    uuid: FIRST_TARGET_UUID,
+    firstTarget: { name: 'MyApp', buildConfigurationList: 'MISSING_LIST' },
+  };
+  mockPbxproj.configurationLists = {};
+  mockPbxproj.buildConfigurations = {};
+  mockPbxproj.objects = {};
+  mockPbxproj.addedBuildPhaseTargets = [];
 });
 
 function makeTmpDir(): string {
@@ -138,32 +210,10 @@ describe('linkBare — iOS Info.plist target selection', () => {
     fs.writeFileSync(debugPlist, MINIMAL_PLIST);
     fs.writeFileSync(releasePlist, MINIMAL_PLIST);
 
-    mockXcodeProject.hash.project.objects = {
-      PBXNativeTarget: {
-        APP_TARGET: {
-          productType: '"com.apple.product-type.application"',
-          buildConfigurationList: 'APP_CONFIGURATIONS',
-        },
-      },
-      XCConfigurationList: {
-        APP_CONFIGURATIONS: {
-          buildConfigurations: [
-            { value: 'DEBUG_CONFIGURATION' },
-            { value: 'RELEASE_CONFIGURATION' },
-          ],
-        },
-      },
-      XCBuildConfiguration: {
-        DEBUG_CONFIGURATION: {
-          buildSettings: { INFOPLIST_FILE: 'Resources/Debug-Info.plist' },
-        },
-        RELEASE_CONFIGURATION: {
-          buildSettings: {
-            INFOPLIST_FILE: '$(SRCROOT)/Resources/Release-Info.plist',
-          },
-        },
-      },
-    };
+    setInfoPlistFiles([
+      'Resources/Debug-Info.plist',
+      '$(SRCROOT)/Resources/Release-Info.plist',
+    ]);
 
     const builtFont: BuiltFont = {
       fontFamily: 'TestFont',
@@ -181,6 +231,53 @@ describe('linkBare — iOS Info.plist target selection', () => {
         path.join(projectRoot, 'ios', 'AppExtension', 'Info.plist')
       )
     ).toEqual([]);
+  });
+
+  test('resolves INFOPLIST_FILE when only getFirstTarget() is available', async () => {
+    fs.rmSync(path.join(projectRoot, 'ios', 'MyApp', 'Info.plist'));
+    const customPlist = path.join(
+      projectRoot,
+      'ios',
+      'Resources',
+      'Info.plist'
+    );
+    fs.mkdirSync(path.dirname(customPlist));
+    fs.writeFileSync(customPlist, MINIMAL_PLIST);
+
+    setInfoPlistFiles(['$(PROJECT_DIR)/Resources/Info.plist'], {
+      resolvableAppTarget: false,
+    });
+
+    const builtFont: BuiltFont = {
+      fontFamily: 'TestFont',
+      ttfPath: path.join(fontDir, 'TestFont.ttf'),
+      glyphmapPath: path.join(fontDir, 'TestFont.glyphmap.json'),
+      linking: 'static',
+    };
+
+    await linkBare(projectRoot, [builtFont], makeLogger());
+
+    expect(readUIAppFonts(customPlist)).toContain('TestFont.ttf');
+    expect(mockPbxproj.addedBuildPhaseTargets).toEqual([FIRST_TARGET_UUID]);
+  });
+
+  test('adds the run script phase to the application target', async () => {
+    setInfoPlistFiles(['MyApp/Info.plist']);
+
+    await linkBare(
+      projectRoot,
+      [
+        {
+          fontFamily: 'TestFont',
+          ttfPath: path.join(fontDir, 'TestFont.ttf'),
+          glyphmapPath: path.join(fontDir, 'TestFont.glyphmap.json'),
+          linking: 'static',
+        },
+      ],
+      makeLogger()
+    );
+
+    expect(mockPbxproj.addedBuildPhaseTargets).toEqual([APP_TARGET_UUID]);
   });
 });
 
@@ -385,7 +482,7 @@ describe('linkBare - platform detection & edge cases', () => {
     ).toBe(true);
   });
 
-  test('does not report iOS as linked when no Info.plist can be resolved', async () => {
+  test('warns and reports no platforms when no Info.plist can be resolved', async () => {
     const iosDir = path.join(projectRoot, 'ios');
     fs.mkdirSync(path.join(iosDir, 'MyApp.xcodeproj'), { recursive: true });
     fs.writeFileSync(
@@ -397,9 +494,40 @@ describe('linkBare - platform detection & edge cases', () => {
     await linkBare(projectRoot, [builtFont('UnlinkedIos')], logger);
 
     expect(fs.existsSync(path.join(projectRoot, IOS_STAGING_DIR))).toBe(false);
-    expect(logger.succeed).toHaveBeenCalledWith(
-      expect.not.stringContaining('ios')
+    expect(logger.warn).toHaveBeenCalledWith(
+      expect.stringContaining('No Info.plist resolved for target "MyApp"')
     );
+    expect(logger.succeed).not.toHaveBeenCalled();
+    expect(logger.fail).toHaveBeenCalledWith('No platforms linked.');
+  });
+
+  test('android still reports as linked when iOS cannot be resolved', async () => {
+    addAndroid();
+    const iosDir = path.join(projectRoot, 'ios');
+    fs.mkdirSync(path.join(iosDir, 'MyApp.xcodeproj'), { recursive: true });
+    fs.writeFileSync(
+      path.join(iosDir, 'MyApp.xcodeproj', 'project.pbxproj'),
+      '// fake pbxproj'
+    );
+    const logger = makeLogger();
+
+    await linkBare(projectRoot, [builtFont('AndroidOnly')], logger);
+
+    expect(logger.succeed).toHaveBeenCalledWith('Linked fonts → android');
+  });
+
+  test('skips iOS when the .xcodeproj has no project.pbxproj', async () => {
+    fs.mkdirSync(path.join(projectRoot, 'ios', 'MyApp.xcodeproj'), {
+      recursive: true,
+    });
+    const logger = makeLogger();
+
+    await linkBare(projectRoot, [builtFont('NoPbxproj')], logger);
+
+    expect(logger.warn).toHaveBeenCalledWith(
+      expect.stringContaining('project.pbxproj not found')
+    );
+    expect(logger.fail).toHaveBeenCalledWith('No platforms linked.');
   });
 
   test('UIAppFonts merges with pre-existing entries without clobbering them', async () => {

--- a/packages/react-native-nano-icons/__tests__/link.xcode.integration.test.ts
+++ b/packages/react-native-nano-icons/__tests__/link.xcode.integration.test.ts
@@ -1,0 +1,121 @@
+/** @jest-environment node */
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import * as plist from 'plist';
+import { linkBare } from '../cli/link';
+import type { NanoLogger } from '../cli/logger';
+
+const EXAMPLE_IOS = path.resolve(
+  __dirname,
+  '../../../examples/BareReactNativeExample/ios'
+);
+
+function makeLogger(): NanoLogger {
+  return {
+    start: jest.fn(),
+    update: jest.fn(),
+    succeed: jest.fn(),
+    fail: jest.fn(),
+    info: jest.fn(),
+    warn: jest.fn(),
+  };
+}
+
+function setupProject(infoPlistSetting?: string): string {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'nano-real-'));
+  const ios = path.join(root, 'ios');
+  fs.mkdirSync(path.join(ios, 'BareReactNativeExample.xcodeproj'), {
+    recursive: true,
+  });
+  let pbxproj = fs.readFileSync(
+    path.join(EXAMPLE_IOS, 'BareReactNativeExample.xcodeproj/project.pbxproj'),
+    'utf8'
+  );
+  if (infoPlistSetting) {
+    pbxproj = pbxproj.replace(
+      /INFOPLIST_FILE = [^;]+;/g,
+      `INFOPLIST_FILE = ${infoPlistSetting};`
+    );
+  }
+  fs.writeFileSync(
+    path.join(ios, 'BareReactNativeExample.xcodeproj/project.pbxproj'),
+    pbxproj
+  );
+  fs.mkdirSync(path.join(ios, 'BareReactNativeExample'), { recursive: true });
+  fs.writeFileSync(
+    path.join(ios, 'BareReactNativeExample', 'Info.plist'),
+    fs.readFileSync(path.join(EXAMPLE_IOS, 'BareReactNativeExample/Info.plist'))
+  );
+  return root;
+}
+
+function font() {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'nano-real-font-'));
+  const ttfPath = path.join(dir, 'RealFont.ttf');
+  fs.writeFileSync(ttfPath, 'fake-ttf');
+  return {
+    fontFamily: 'RealFont',
+    ttfPath,
+    glyphmapPath: `${ttfPath}.json`,
+    linking: 'static' as const,
+  };
+}
+
+function uiAppFonts(p: string): string[] {
+  const parsed = plist.parse(fs.readFileSync(p, 'utf8')) as Record<
+    string,
+    unknown
+  >;
+  return (parsed['UIAppFonts'] as string[]) ?? [];
+}
+
+test('real pbxproj — conventional INFOPLIST_FILE', async () => {
+  const root = setupProject();
+  const logger = makeLogger();
+  await linkBare(root, [font()], logger);
+  expect(
+    uiAppFonts(path.join(root, 'ios/BareReactNativeExample/Info.plist'))
+  ).toContain('RealFont.ttf');
+  expect(logger.succeed).toHaveBeenCalledWith('Linked fonts → ios');
+  const written = fs.readFileSync(
+    path.join(root, 'ios/BareReactNativeExample.xcodeproj/project.pbxproj'),
+    'utf8'
+  );
+  expect(written).toContain('Copy nanoicons fonts');
+});
+
+test('real pbxproj — custom INFOPLIST_FILE with $(SRCROOT)', async () => {
+  const root = setupProject('"$(SRCROOT)/Resources/Custom-Info.plist"');
+  const custom = path.join(root, 'ios/Resources/Custom-Info.plist');
+  fs.mkdirSync(path.dirname(custom), { recursive: true });
+  fs.writeFileSync(custom, plist.build({ CFBundleName: 'custom' }));
+  const logger = makeLogger();
+
+  await linkBare(root, [font()], logger);
+
+  expect(uiAppFonts(custom)).toContain('RealFont.ttf');
+  expect(
+    uiAppFonts(path.join(root, 'ios/BareReactNativeExample/Info.plist'))
+  ).not.toContain('RealFont.ttf');
+  expect(logger.succeed).toHaveBeenCalledWith('Linked fonts → ios');
+});
+
+test('real pbxproj — the run script phase lands on the application target', async () => {
+  const root = setupProject();
+  await linkBare(root, [font()], makeLogger());
+  const xcode = require('xcode') as typeof import('xcode');
+  const p = xcode
+    .project(
+      path.join(root, 'ios/BareReactNativeExample.xcodeproj/project.pbxproj')
+    )
+    .parseSync();
+  const appTarget = p.getTarget('com.apple.product-type.application')!;
+  const phaseUuids = appTarget.target.buildPhases.map((b) => b.value);
+  const shellPhases = p.hash.project.objects['PBXShellScriptBuildPhase']!;
+  const names = phaseUuids
+    .map((u) => shellPhases[u])
+    .filter((o): o is Record<string, unknown> => typeof o === 'object')
+    .map((o) => o['name']);
+  expect(names).toContain('"Copy nanoicons fonts"');
+});

--- a/packages/react-native-nano-icons/cli/link.ts
+++ b/packages/react-native-nano-icons/cli/link.ts
@@ -13,7 +13,7 @@ type ShellScriptOptions = {
 
 type XcodeProject = {
   parseSync: () => XcodeProject;
-  getFirstTarget: () => { uuid: string };
+  getFirstTarget: () => { uuid: string; buildConfigurationList?: unknown };
   addBuildPhase: (
     filePaths: string[],
     phaseType: string,
@@ -24,17 +24,101 @@ type XcodeProject = {
   writeSync: () => string;
   hash: {
     project: {
-      objects: Record<
-        string,
-        Record<string, { name?: string; shellScript?: string }>
-      >;
+      objects: Record<string, Record<string, XcodeObject>>;
     };
   };
+};
+
+type XcodeObject = {
+  buildConfigurationList?: unknown;
+  buildConfigurations?: unknown;
+  buildSettings?: Record<string, unknown>;
+  name?: string;
+  productType?: string;
+  shellScript?: string;
 };
 
 const ANDROID_FONTS_DIR = 'android/app/src/main/assets/fonts';
 const IOS_NANOICONS_FONTS_DIR = 'nanoicons-fonts';
 const IOS_RUN_SCRIPT_PHASE_NAME = 'Copy nanoicons fonts';
+
+function xcodeReferenceUuid(reference: unknown): string | undefined {
+  if (typeof reference === 'string') return reference;
+  if (
+    typeof reference === 'object' &&
+    reference !== null &&
+    'value' in reference &&
+    typeof reference.value === 'string'
+  ) {
+    return reference.value;
+  }
+  return undefined;
+}
+
+function getFirstAppTarget(project: XcodeProject): {
+  uuid: string;
+  target: XcodeObject;
+} {
+  const targets = project.hash.project.objects['PBXNativeTarget'] ?? {};
+  const appTarget = Object.entries(targets).find(
+    ([uuid, target]) =>
+      !uuid.endsWith('_comment') &&
+      target.productType?.replace(/['\"]/g, '') ===
+        'com.apple.product-type.application'
+  );
+
+  if (appTarget) return { uuid: appTarget[0], target: appTarget[1] };
+
+  const target = project.getFirstTarget();
+  return { uuid: target.uuid, target };
+}
+
+function resolveInfoPlistPaths(
+  project: XcodeProject,
+  iosDir: string,
+  fallbackPath: string
+): string[] {
+  const { target } = getFirstAppTarget(project);
+  const configurationListUuid = xcodeReferenceUuid(
+    target.buildConfigurationList
+  );
+  const configurationList = configurationListUuid
+    ? project.hash.project.objects['XCConfigurationList']?.[
+        configurationListUuid
+      ]
+    : undefined;
+  const buildConfigurationUuids = Array.isArray(
+    configurationList?.buildConfigurations
+  )
+    ? configurationList.buildConfigurations
+        .map(xcodeReferenceUuid)
+        .filter((uuid): uuid is string => uuid !== undefined)
+    : [];
+
+  const paths = buildConfigurationUuids
+    .map(
+      (uuid) =>
+        project.hash.project.objects['XCBuildConfiguration']?.[uuid]
+          ?.buildSettings?.['INFOPLIST_FILE']
+    )
+    .filter((setting): setting is string => typeof setting === 'string')
+    .map((setting) =>
+      setting
+        .replace(/^['\"]|['\"]$/g, '')
+        .replace(
+          /\$\((?:SRCROOT|PROJECT_DIR)\)|\$\{(?:SRCROOT|PROJECT_DIR)\}/g,
+          iosDir
+        )
+    )
+    .map((setting) => path.resolve(iosDir, setting))
+    .filter((plistPath) => fs.existsSync(plistPath));
+
+  return paths.length
+    ? [...new Set(paths)]
+    : fs.existsSync(fallbackPath)
+      ? [fallbackPath]
+      : [];
+}
 
 async function linkAndroid(
   projectRoot: string,
@@ -52,18 +136,27 @@ async function linkAndroid(
 async function linkIos(
   projectRoot: string,
   builtFonts: BuiltFont[]
-): Promise<void> {
+): Promise<boolean> {
   const iosDir = path.join(projectRoot, 'ios');
 
   const xcodeprojDir = fs
     .readdirSync(iosDir, { withFileTypes: true })
     .find((d) => d.name.endsWith('.xcodeproj'));
 
-  if (!xcodeprojDir) return;
+  if (!xcodeprojDir) return false;
 
   const appName = xcodeprojDir.name.replace(/\.xcodeproj$/, '');
-  const infoPlistPath = path.join(iosDir, appName, 'Info.plist');
-  if (!fs.existsSync(infoPlistPath)) return;
+  const pbxprojPath = path.join(iosDir, xcodeprojDir.name, 'project.pbxproj');
+  const xcode = require('xcode') as { project: (p: string) => XcodeProject };
+  const project = xcode.project(pbxprojPath);
+  project.parseSync();
+
+  const infoPlistPaths = resolveInfoPlistPaths(
+    project,
+    iosDir,
+    path.join(iosDir, appName, 'Info.plist')
+  );
+  if (!infoPlistPaths.length) return false;
 
   const fontNames: string[] = [];
   const iosFontsStaging = path.join(iosDir, IOS_NANOICONS_FONTS_DIR);
@@ -75,24 +168,20 @@ async function linkIos(
     fs.copyFileSync(b.ttfPath, path.join(iosFontsStaging, name));
   }
 
-  const plistContent = fs.readFileSync(infoPlistPath, 'utf8');
-  const obj = plist.parse(plistContent) as plist.PlistObject;
-
-  const existing = Array.isArray((obj as Record<string, unknown>)['UIAppFonts'])
-    ? ((obj as Record<string, unknown>)['UIAppFonts'] as string[])
-    : [];
-
-  const merged = [...new Set([...existing, ...fontNames])];
-  const updated: plist.PlistObject = {
-    ...(obj as Record<string, unknown>),
-    UIAppFonts: merged,
-  };
-  fs.writeFileSync(infoPlistPath, plist.build(updated), 'utf8');
-
-  const pbxprojPath = path.join(iosDir, xcodeprojDir.name, 'project.pbxproj');
-  const xcode = require('xcode') as { project: (p: string) => XcodeProject };
-  const project = xcode.project(pbxprojPath);
-  project.parseSync();
+  for (const infoPlistPath of infoPlistPaths) {
+    const plistContent = fs.readFileSync(infoPlistPath, 'utf8');
+    const obj = plist.parse(plistContent) as plist.PlistObject;
+    const existing = Array.isArray(
+      (obj as Record<string, unknown>)['UIAppFonts']
+    )
+      ? ((obj as Record<string, unknown>)['UIAppFonts'] as string[])
+      : [];
+    const updated: plist.PlistObject = {
+      ...(obj as Record<string, unknown>),
+      UIAppFonts: [...new Set([...existing, ...fontNames])],
+    };
+    fs.writeFileSync(infoPlistPath, plist.build(updated), 'utf8');
+  }
 
   const hasPhase = Object.entries(
     project.hash.project.objects['PBXShellScriptBuildPhase'] ?? {}
@@ -113,12 +202,14 @@ async function linkIos(
       [],
       'PBXShellScriptBuildPhase',
       IOS_RUN_SCRIPT_PHASE_NAME,
-      project.getFirstTarget().uuid,
+      getFirstAppTarget(project).uuid,
       { shellPath: '/bin/sh', shellScript: script }
     );
 
     fs.writeFileSync(pbxprojPath, project.writeSync(), 'utf8');
   }
+
+  return true;
 }
 
 /**
@@ -176,8 +267,9 @@ export async function linkBare(
   }
 
   if (hasIos) {
-    await linkIos(projectRoot, staticFonts);
-    linkedPlatforms.push('ios');
+    if (await linkIos(projectRoot, staticFonts)) {
+      linkedPlatforms.push('ios');
+    }
   }
 
   const dynamicSuffix = dynamicFonts.length

--- a/packages/react-native-nano-icons/cli/link.ts
+++ b/packages/react-native-nano-icons/cli/link.ts
@@ -1,123 +1,83 @@
 import fs from 'node:fs';
 import path from 'node:path';
 import * as plist from 'plist';
+import type { PBXNativeTarget, XcodeProject } from 'xcode';
 import type { NanoLogger } from './logger.js';
 import type { BuiltFont } from './build.js';
-
-type ShellScriptOptions = {
-  shellPath?: string;
-  shellScript: string;
-  inputPaths?: string[];
-  outputPaths?: string[];
-};
-
-type XcodeProject = {
-  parseSync: () => XcodeProject;
-  getFirstTarget: () => { uuid: string; buildConfigurationList?: unknown };
-  addBuildPhase: (
-    filePaths: string[],
-    phaseType: string,
-    comment: string,
-    target: string,
-    options?: ShellScriptOptions
-  ) => void;
-  writeSync: () => string;
-  hash: {
-    project: {
-      objects: Record<string, Record<string, XcodeObject>>;
-    };
-  };
-};
-
-type XcodeObject = {
-  buildConfigurationList?: unknown;
-  buildConfigurations?: unknown;
-  buildSettings?: Record<string, unknown>;
-  name?: string;
-  productType?: string;
-  shellScript?: string;
-};
 
 const ANDROID_FONTS_DIR = 'android/app/src/main/assets/fonts';
 const IOS_NANOICONS_FONTS_DIR = 'nanoicons-fonts';
 const IOS_RUN_SCRIPT_PHASE_NAME = 'Copy nanoicons fonts';
+const IOS_APPLICATION_PRODUCT_TYPE = 'com.apple.product-type.application';
+const XCODE_PROJECT_DIR_VARIABLE = /\$[({](?:SRCROOT|PROJECT_DIR)[)}]/g;
+const SURROUNDING_QUOTES = /^["']|["']$/g;
 
-function xcodeReferenceUuid(reference: unknown): string | undefined {
-  if (typeof reference === 'string') return reference;
-  if (
-    typeof reference === 'object' &&
-    reference !== null &&
-    'value' in reference &&
-    typeof reference.value === 'string'
-  ) {
-    return reference.value;
-  }
-  return undefined;
-}
-
-function getFirstAppTarget(project: XcodeProject): {
+function getAppTarget(project: XcodeProject): {
   uuid: string;
-  target: XcodeObject;
+  target: PBXNativeTarget;
 } {
-  const targets = project.hash.project.objects['PBXNativeTarget'] ?? {};
-  const appTarget = Object.entries(targets).find(
-    ([uuid, target]) =>
-      !uuid.endsWith('_comment') &&
-      target.productType?.replace(/['\"]/g, '') ===
-        'com.apple.product-type.application'
-  );
+  const appTarget = project.getTarget(IOS_APPLICATION_PRODUCT_TYPE);
+  if (appTarget) return appTarget;
 
-  if (appTarget) return { uuid: appTarget[0], target: appTarget[1] };
-
-  const target = project.getFirstTarget();
-  return { uuid: target.uuid, target };
+  const { uuid, firstTarget } = project.getFirstTarget();
+  return { uuid, target: firstTarget };
 }
 
 function resolveInfoPlistPaths(
   project: XcodeProject,
+  target: PBXNativeTarget,
   iosDir: string,
   fallbackPath: string
 ): string[] {
-  const { target } = getFirstAppTarget(project);
-  const configurationListUuid = xcodeReferenceUuid(
-    target.buildConfigurationList
+  const configurationList =
+    project.pbxXCConfigurationList()[target.buildConfigurationList];
+  const buildConfigurations = project.pbxXCBuildConfigurationSection();
+
+  const configuredPaths = new Set<string>();
+
+  if (typeof configurationList === 'object') {
+    for (const { value } of configurationList.buildConfigurations) {
+      const configuration = buildConfigurations[value];
+      if (typeof configuration !== 'object') continue;
+
+      const setting = configuration.buildSettings['INFOPLIST_FILE'];
+      if (typeof setting !== 'string') continue;
+
+      configuredPaths.add(
+        path.resolve(
+          iosDir,
+          setting
+            .replace(SURROUNDING_QUOTES, '')
+            .replace(XCODE_PROJECT_DIR_VARIABLE, iosDir)
+        )
+      );
+    }
+  }
+
+  const existingPaths = [...configuredPaths].filter((plistPath) =>
+    fs.existsSync(plistPath)
   );
-  const configurationList = configurationListUuid
-    ? project.hash.project.objects['XCConfigurationList']?.[
-        configurationListUuid
-      ]
-    : undefined;
-  const buildConfigurationUuids = Array.isArray(
-    configurationList?.buildConfigurations
-  )
-    ? configurationList.buildConfigurations
-        .map(xcodeReferenceUuid)
-        .filter((uuid): uuid is string => uuid !== undefined)
+  if (existingPaths.length) return existingPaths;
+
+  return fs.existsSync(fallbackPath) ? [fallbackPath] : [];
+}
+
+function addUIAppFonts(infoPlistPath: string, fontNames: string[]): void {
+  const parsed = plist.parse(fs.readFileSync(infoPlistPath, 'utf8')) as Record<
+    string,
+    unknown
+  >;
+
+  const existing = Array.isArray(parsed['UIAppFonts'])
+    ? (parsed['UIAppFonts'] as string[])
     : [];
 
-  const paths = buildConfigurationUuids
-    .map(
-      (uuid) =>
-        project.hash.project.objects['XCBuildConfiguration']?.[uuid]
-          ?.buildSettings?.['INFOPLIST_FILE']
-    )
-    .filter((setting): setting is string => typeof setting === 'string')
-    .map((setting) =>
-      setting
-        .replace(/^['\"]|['\"]$/g, '')
-        .replace(
-          /\$\((?:SRCROOT|PROJECT_DIR)\)|\$\{(?:SRCROOT|PROJECT_DIR)\}/g,
-          iosDir
-        )
-    )
-    .map((setting) => path.resolve(iosDir, setting))
-    .filter((plistPath) => fs.existsSync(plistPath));
+  const updated: plist.PlistObject = {
+    ...parsed,
+    UIAppFonts: [...new Set([...existing, ...fontNames])],
+  };
 
-  return paths.length
-    ? [...new Set(paths)]
-    : fs.existsSync(fallbackPath)
-      ? [fallbackPath]
-      : [];
+  fs.writeFileSync(infoPlistPath, plist.build(updated), 'utf8');
 }
 
 async function linkAndroid(
@@ -135,7 +95,8 @@ async function linkAndroid(
 
 async function linkIos(
   projectRoot: string,
-  builtFonts: BuiltFont[]
+  builtFonts: BuiltFont[],
+  logger: NanoLogger
 ): Promise<boolean> {
   const iosDir = path.join(projectRoot, 'ios');
 
@@ -143,20 +104,38 @@ async function linkIos(
     .readdirSync(iosDir, { withFileTypes: true })
     .find((d) => d.name.endsWith('.xcodeproj'));
 
-  if (!xcodeprojDir) return false;
+  if (!xcodeprojDir) {
+    logger.warn(`No .xcodeproj found in ${iosDir} — skipping iOS linking.`);
+    return false;
+  }
+
+  const pbxprojPath = path.join(iosDir, xcodeprojDir.name, 'project.pbxproj');
+  if (!fs.existsSync(pbxprojPath)) {
+    logger.warn(
+      `${path.relative(projectRoot, pbxprojPath)} not found — skipping iOS linking.`
+    );
+    return false;
+  }
+
+  const xcode = require('xcode') as typeof import('xcode');
+  const project = xcode.project(pbxprojPath).parseSync();
 
   const appName = xcodeprojDir.name.replace(/\.xcodeproj$/, '');
-  const pbxprojPath = path.join(iosDir, xcodeprojDir.name, 'project.pbxproj');
-  const xcode = require('xcode') as { project: (p: string) => XcodeProject };
-  const project = xcode.project(pbxprojPath);
-  project.parseSync();
-
+  const { uuid: targetUuid, target } = getAppTarget(project);
   const infoPlistPaths = resolveInfoPlistPaths(
     project,
+    target,
     iosDir,
     path.join(iosDir, appName, 'Info.plist')
   );
-  if (!infoPlistPaths.length) return false;
+
+  if (!infoPlistPaths.length) {
+    logger.warn(
+      `No Info.plist resolved for target "${target.name}" — set INFOPLIST_FILE in its build settings, ` +
+        `or place one at ios/${appName}/Info.plist. Skipping iOS linking.`
+    );
+    return false;
+  }
 
   const fontNames: string[] = [];
   const iosFontsStaging = path.join(iosDir, IOS_NANOICONS_FONTS_DIR);
@@ -169,25 +148,16 @@ async function linkIos(
   }
 
   for (const infoPlistPath of infoPlistPaths) {
-    const plistContent = fs.readFileSync(infoPlistPath, 'utf8');
-    const obj = plist.parse(plistContent) as plist.PlistObject;
-    const existing = Array.isArray(
-      (obj as Record<string, unknown>)['UIAppFonts']
-    )
-      ? ((obj as Record<string, unknown>)['UIAppFonts'] as string[])
-      : [];
-    const updated: plist.PlistObject = {
-      ...(obj as Record<string, unknown>),
-      UIAppFonts: [...new Set([...existing, ...fontNames])],
-    };
-    fs.writeFileSync(infoPlistPath, plist.build(updated), 'utf8');
+    addUIAppFonts(infoPlistPath, fontNames);
   }
 
-  const hasPhase = Object.entries(
+  const hasPhase = Object.values(
     project.hash.project.objects['PBXShellScriptBuildPhase'] ?? {}
   ).some(
-    ([, v]) =>
-      typeof v === 'object' && v?.name?.includes(IOS_RUN_SCRIPT_PHASE_NAME)
+    (phase) =>
+      typeof phase === 'object' &&
+      typeof phase['name'] === 'string' &&
+      phase['name'].includes(IOS_RUN_SCRIPT_PHASE_NAME)
   );
 
   if (!hasPhase) {
@@ -202,7 +172,7 @@ async function linkIos(
       [],
       'PBXShellScriptBuildPhase',
       IOS_RUN_SCRIPT_PHASE_NAME,
-      getFirstAppTarget(project).uuid,
+      targetUuid,
       { shellPath: '/bin/sh', shellScript: script }
     );
 
@@ -266,10 +236,8 @@ export async function linkBare(
     linkedPlatforms.push('android');
   }
 
-  if (hasIos) {
-    if (await linkIos(projectRoot, staticFonts)) {
-      linkedPlatforms.push('ios');
-    }
+  if (hasIos && (await linkIos(projectRoot, staticFonts, logger))) {
+    linkedPlatforms.push('ios');
   }
 
   const dynamicSuffix = dynamicFonts.length
@@ -277,6 +245,12 @@ export async function linkBare(
         dynamicFonts.length === 1 ? '' : 's'
       } skipped)`
     : '';
+
+  if (!linkedPlatforms.length) {
+    logger.fail(`No platforms linked${dynamicSuffix}.`);
+    return;
+  }
+
   logger.succeed(
     `Linked fonts → ${linkedPlatforms.join(', ')}${dynamicSuffix}`
   );

--- a/packages/react-native-nano-icons/package.json
+++ b/packages/react-native-nano-icons/package.json
@@ -71,6 +71,7 @@
     "@types/plist": "^3.0.5",
     "@types/react": "~19.1.0",
     "@types/svg2ttf": "^5.0.3",
+    "@types/xcode": "^3.0.0",
     "babel-plugin-module-resolver": "^5.0.2",
     "del-cli": "^6.0.0",
     "expo-module-scripts": "^5.0.8",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5476,6 +5476,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/xcode@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "@types/xcode@npm:3.0.0"
+  checksum: 10c0/549cd3df02ce1d385a5d23e662f2600ccad4f1b07e41e8d64b99957663b2ee2f1b9f7160bc41d946ba9986d2d42ecda9312458528a6e98e0dd30c72510f5d3f4
+  languageName: node
+  linkType: hard
+
 "@types/yargs-parser@npm:*":
   version: 21.0.3
   resolution: "@types/yargs-parser@npm:21.0.3"
@@ -15007,6 +15014,7 @@ __metadata:
     "@types/plist": "npm:^3.0.5"
     "@types/react": "npm:~19.1.0"
     "@types/svg2ttf": "npm:^5.0.3"
+    "@types/xcode": "npm:^3.0.0"
     "@xmldom/xmldom": "npm:^0.9.10"
     babel-plugin-module-resolver: "npm:^5.0.2"
     chalk: "npm:^5.6.2"


### PR DESCRIPTION
## Description

Thank you for this great package. We’re introducing it in our Brownfield React Native app and really appreciate the SVG-to-font workflow. We're migrating from icomoon and manually merging fonts so this workflow is much nicer.

While setting up static linking, the CLI reported:

```text
Linked fonts → android, ios
```

Android linked correctly, but no icons appeared on iOS. There was no warning or error.

Our app uses a valid custom Xcode layout where the application target sets:

```text
INFOPLIST_FILE = Resources/Info.plist
```

The iOS linker currently assumes the plist is at:

```text
ios/<xcodeproj-name>/Info.plist
```

When that conventional path does not exist, iOS linking returns early. `linkBare()` still reports iOS as linked, which makes this failure silent.

This is a follow-up to #15: that PR correctly avoided selecting an arbitrary `Info.plist`, but the replacement assumption does not support projects that configure their plist through `INFOPLIST_FILE`.

This PR:

- resolves existing `INFOPLIST_FILE` values from the first application target’s build configurations;
- supports `$(SRCROOT)` and `$(PROJECT_DIR)` path variables;
- updates every distinct, existing plist configured for that target;
- retains `ios/<app-name>/Info.plist` as a fallback;
- avoids staging fonts and reporting iOS as linked when no valid plist can be resolved.

## Test plan

Added unit coverage for:

- conventional `ios/<app>/Info.plist` fallback;
- custom per-configuration `INFOPLIST_FILE` paths;
- `$(SRCROOT)` / `$(PROJECT_DIR)` path expansion;
- iOS projects without a resolvable plist not being reported as linked.
