### PR TITLE
feat: support PlatformColor and DynamicColorIOS

### DIFF
--- a/examples/ExpoExample/app.json
+++ b/examples/ExpoExample/app.json
@@ -5,7 +5,7 @@
     "version": "1.0.0",
     "orientation": "portrait",
     "icon": "./assets/icon.png",
-    "userInterfaceStyle": "light",
+    "userInterfaceStyle": "automatic",
     "newArchEnabled": true,
     "splash": {
       "image": "./assets/splash-icon.png",

--- a/examples/ExpoExample/app/(tabs)/_layout.tsx
+++ b/examples/ExpoExample/app/(tabs)/_layout.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import FontAwesome from '@expo/vector-icons/FontAwesome';
-import { Link, Tabs } from 'expo-router';
-import { Pressable } from 'react-native';
+import { Tabs } from 'expo-router';
 
 import Colors from '@/constants/Colors';
 import { useColorScheme } from '@/components/useColorScheme';
@@ -45,6 +44,16 @@ export default function TabLayout() {
         options={{
           title: '(Nano)Material TwoTone Icons',
           tabBarIcon: ({ color }) => <TabBarIcon name="code" color={color} />,
+        }}
+      />
+      <Tabs.Screen
+        name="colors"
+        options={{
+          title: 'Platform Colors',
+          tabBarLabel: 'Colors',
+          tabBarIcon: ({ color }) => (
+            <TabBarIcon name="paint-brush" color={color} />
+          ),
         }}
       />
     </Tabs>

--- a/examples/ExpoExample/app/(tabs)/colors.tsx
+++ b/examples/ExpoExample/app/(tabs)/colors.tsx
@@ -1,0 +1,205 @@
+import {
+  DynamicColorIOS,
+  Platform,
+  PlatformColor,
+  ScrollView,
+  StyleSheet,
+  View,
+  type ColorValue,
+} from 'react-native';
+import { SafeAreaProvider, SafeAreaView } from 'react-native-safe-area-context';
+import { Icon } from '@/components/Icon';
+import { Text, useThemeColor } from '@/components/Themed';
+
+const IS_IOS = Platform.OS === 'ios';
+
+// DynamicColorIOS throws off iOS, so it may only be called behind this guard.
+const adaptive: ColorValue = IS_IOS
+  ? DynamicColorIOS({ light: '#0a3161', dark: '#7aa7ff' })
+  : PlatformColor('?android:attr/colorForeground');
+
+const platformColors: { label: string; color: ColorValue }[] = Platform.select({
+  ios: [
+    {
+      label: "PlatformColor('labelColor')",
+      color: PlatformColor('labelColor'),
+    },
+    {
+      label: "PlatformColor('systemRedColor')",
+      color: PlatformColor('systemRedColor'),
+    },
+    {
+      label: "PlatformColor('systemBlueColor')",
+      color: PlatformColor('systemBlueColor'),
+    },
+  ],
+  default: [
+    {
+      label: "PlatformColor('?attr/colorPrimary')",
+      color: PlatformColor('?attr/colorPrimary'),
+    },
+    {
+      label: "PlatformColor('@android:color/holo_red_dark')",
+      color: PlatformColor('@android:color/holo_red_dark'),
+    },
+    {
+      label: "PlatformColor('@android:color/holo_blue_dark')",
+      color: PlatformColor('@android:color/holo_blue_dark'),
+    },
+  ],
+});
+
+// The same 24-layer palette index.tsx overrides person-walking with, except the
+// four shirt layers, which are adaptive — the other 20 stay static hex.
+const walkerColors: ColorValue[] = [
+  '#FCC9A7',
+  '#1F252A',
+  '#FCC9A7',
+  '#1F252A',
+  '#092330',
+  '#0C2C40',
+  '#FCC9A7',
+  '#1C2226',
+  adaptive, // shirt
+  adaptive, // shirt
+  '#FCC9A7',
+  '#F4BE9A',
+  '#FCC9A7',
+  '#045286',
+  '#FCC9A7',
+  '#ff166f',
+  adaptive, // shirt
+  '#EADDD8',
+  '#AFAFAF',
+  '#D1D1D1',
+  '#FCC9A7',
+  adaptive, // shirt
+  '#EADDD8',
+  '#1C2226',
+];
+
+const Section = ({
+  title,
+  hint,
+  children,
+}: {
+  title: string;
+  hint: string;
+  children: React.ReactNode;
+}) => (
+  <View style={styles.section}>
+    <Text style={styles.sectionTitle}>{title}</Text>
+    <Text style={styles.hint}>{hint}</Text>
+    {children}
+  </View>
+);
+
+// The icon and the label share one ColorValue — if they ever differ, the icon
+// resolved it wrong.
+const Row = ({ label, color }: { label: string; color: ColorValue }) => (
+  <View style={styles.row}>
+    <Icon name="star" size={36} color={color} />
+    <Text style={[styles.rowLabel, { color }]}>{label}</Text>
+  </View>
+);
+
+export default function ColorsScreen() {
+  const screenBackground = useThemeColor({}, 'screenBackground');
+
+  return (
+    <SafeAreaProvider>
+      <SafeAreaView
+        edges={['top']}
+        style={[styles.container, { backgroundColor: screenBackground }]}>
+        <ScrollView contentContainerStyle={styles.scrollContent}>
+          <Text style={styles.intro}>
+            Every icon below shares its exact ColorValue with the text beside
+            it. Toggle light/dark appearance — the two must always match.
+          </Text>
+
+          <Section
+            title="DynamicColorIOS"
+            hint={
+              IS_IOS
+                ? 'Resolves per user interface style, live, without a re-render.'
+                : 'iOS only — DynamicColorIOS throws on this platform.'
+            }>
+            {IS_IOS ? (
+              <Row
+                label="DynamicColorIOS({ light: '#0a3161', dark: '#7aa7ff' })"
+                color={adaptive}
+              />
+            ) : null}
+          </Section>
+
+          <Section
+            title="PlatformColor"
+            hint={
+              IS_IOS
+                ? 'UIColor semantic colors. labelColor is itself trait-dependent.'
+                : 'Theme attributes and framework color resources.'
+            }>
+            {platformColors.map(({ label, color }) => (
+              <Row key={label} label={label} color={color} />
+            ))}
+          </Section>
+
+          <Section
+            title="Adaptive layers among static ones"
+            hint="Only the shirt is adaptive; the other 20 layers are static hex.">
+            <View style={styles.row}>
+              <Icon name="person-walking" size={110} color={walkerColors} />
+              <Text style={styles.rowLabel}>
+                person-walking, shirt layers adaptive
+              </Text>
+            </View>
+          </Section>
+
+          <Section
+            title="Inline in <Text>"
+            hint="Inline icons draw through a CALayer, which resolves traits separately.">
+            <Text style={[styles.rowLabel, { color: adaptive }]}>
+              A star <Icon name="star" size={20} color={adaptive} /> inline in a
+              sentence.
+            </Text>
+          </Section>
+        </ScrollView>
+      </SafeAreaView>
+    </SafeAreaProvider>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+  },
+  scrollContent: {
+    padding: 16,
+    gap: 28,
+  },
+  intro: {
+    fontSize: 14,
+    opacity: 0.7,
+  },
+  section: {
+    gap: 8,
+  },
+  sectionTitle: {
+    fontSize: 18,
+    fontWeight: '600',
+  },
+  hint: {
+    fontSize: 13,
+    opacity: 0.7,
+    marginBottom: 4,
+  },
+  row: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 12,
+  },
+  rowLabel: {
+    fontSize: 15,
+    flexShrink: 1,
+  },
+});

--- a/examples/ExpoExample/app/(tabs)/index.tsx
+++ b/examples/ExpoExample/app/(tabs)/index.tsx
@@ -1,11 +1,22 @@
-import { Pressable, ScrollView, StyleSheet, Text, View } from 'react-native';
+import {
+  DynamicColorIOS,
+  Pressable,
+  ScrollView,
+  StyleSheet,
+  View,
+} from 'react-native';
 import { SafeAreaProvider, SafeAreaView } from 'react-native-safe-area-context';
 import { Icon, SWMIconsOutline } from '@/components/Icon';
+import { Text, useThemeColor } from '@/components/Themed';
 
 export default function TabOneScreen() {
+  const screenBackground = useThemeColor({}, 'screenBackground');
+
   return (
     <SafeAreaProvider>
-      <SafeAreaView edges={['top']} style={styles.container}>
+      <SafeAreaView
+        edges={['top']}
+        style={[styles.container, { backgroundColor: screenBackground }]}>
         <ScrollView
           style={styles.scroll}
           contentContainerStyle={styles.scrollContent}>
@@ -17,7 +28,11 @@ export default function TabOneScreen() {
             <Text style={styles.subtitle}>Standalone icon:</Text>
             <Icon name="react-logo" size={80} />
             <Pressable style={styles.button}>
-              <SWMIconsOutline name="ZoomIn" size={28} color={'#007AFF'} />
+              <SWMIconsOutline
+                name="ZoomIn"
+                size={28}
+                color={DynamicColorIOS({ light: '#007AFF', dark: '#0A84FF' })}
+              />
               <Text style={styles.buttonText}>Monochrome Button Icon</Text>
             </Pressable>
           </View>
@@ -73,7 +88,6 @@ export default function TabOneScreen() {
 const styles = StyleSheet.create({
   container: {
     flex: 1,
-    backgroundColor: '#eee',
     justifyContent: 'center',
     alignItems: 'center',
   },
@@ -101,7 +115,7 @@ const styles = StyleSheet.create({
     gap: 10,
   },
   buttonText: {
-    color: '#007AFF',
+    color: DynamicColorIOS({ light: 'green', dark: 'red' }),
     textAlignVertical: 'center',
     fontSize: 25,
   },

--- a/examples/ExpoExample/app/(tabs)/index.tsx
+++ b/examples/ExpoExample/app/(tabs)/index.tsx
@@ -1,10 +1,4 @@
-import {
-  DynamicColorIOS,
-  Pressable,
-  ScrollView,
-  StyleSheet,
-  View,
-} from 'react-native';
+import { Pressable, ScrollView, StyleSheet, View } from 'react-native';
 import { SafeAreaProvider, SafeAreaView } from 'react-native-safe-area-context';
 import { Icon, SWMIconsOutline } from '@/components/Icon';
 import { Text, useThemeColor } from '@/components/Themed';
@@ -28,11 +22,7 @@ export default function TabOneScreen() {
             <Text style={styles.subtitle}>Standalone icon:</Text>
             <Icon name="react-logo" size={80} />
             <Pressable style={styles.button}>
-              <SWMIconsOutline
-                name="ZoomIn"
-                size={28}
-                color={DynamicColorIOS({ light: '#007AFF', dark: '#0A84FF' })}
-              />
+              <SWMIconsOutline name="ZoomIn" size={28} color={'#007AFF'} />
               <Text style={styles.buttonText}>Monochrome Button Icon</Text>
             </Pressable>
           </View>
@@ -115,7 +105,7 @@ const styles = StyleSheet.create({
     gap: 10,
   },
   buttonText: {
-    color: DynamicColorIOS({ light: 'green', dark: 'red' }),
+    color: '#007AFF',
     textAlignVertical: 'center',
     fontSize: 25,
   },

--- a/examples/ExpoExample/app/(tabs)/material.tsx
+++ b/examples/ExpoExample/app/(tabs)/material.tsx
@@ -1,23 +1,22 @@
-import { FlatList } from "react-native";
+import { FlatList } from 'react-native';
 
-import { Text, View } from "@/components/Themed";
-import materialIconGlyphMap from "@/assets/nanoicons/MaterialIconsTwotone.glyphmap.json";
-import { MaterialIcon } from "@/components/Icon";
+import { Text, View, useThemeColor } from '@/components/Themed';
+import materialIconGlyphMap from '@/assets/nanoicons/MaterialIconsTwotone.glyphmap.json';
+import { MaterialIcon } from '@/components/Icon';
 
 const iconSubset = Object.keys(
-  materialIconGlyphMap.i,
+  materialIconGlyphMap.i
 ) as (keyof typeof materialIconGlyphMap.i)[];
 
 const Row = ({ icon }: { icon: keyof typeof materialIconGlyphMap.i }) => {
   return (
     <View
       style={{
-        flexDirection: "row",
+        flexDirection: 'row',
         gap: 10,
         paddingVertical: 10,
-        alignItems: "center",
-      }}
-    >
+        alignItems: 'center',
+      }}>
       <MaterialIcon name={icon} size={42} />
       <Text style={{ fontSize: 24 }}>{icon}</Text>
     </View>
@@ -25,14 +24,16 @@ const Row = ({ icon }: { icon: keyof typeof materialIconGlyphMap.i }) => {
 };
 
 export default function MaterialScreen() {
+  const background = useThemeColor({}, 'background');
+
   return (
     <FlatList
+      style={{ backgroundColor: background }}
       data={iconSubset}
       keyExtractor={(item) => item}
       renderItem={({ item }) => <Row icon={item} />}
       contentContainerStyle={{
         paddingHorizontal: 10,
-        backgroundColor: "white",
       }}
     />
   );

--- a/examples/ExpoExample/app/(tabs)/two.tsx
+++ b/examples/ExpoExample/app/(tabs)/two.tsx
@@ -1,6 +1,6 @@
 import { FlatList } from 'react-native';
 
-import { Text, View } from '@/components/Themed';
+import { Text, View, useThemeColor } from '@/components/Themed';
 import swmIconGlyphMap from '@/assets/nanoicons/SWMIconsOutline.glyphmap.json';
 import { SWMIconsOutline } from '@/components/Icon';
 
@@ -35,15 +35,17 @@ const DynamicHeader = () => (
 );
 
 export default function TabTwoScreen() {
+  const background = useThemeColor({}, 'background');
+
   return (
     <FlatList
+      style={{ backgroundColor: background }}
       data={iconSubset}
       keyExtractor={(item) => item}
       ListHeaderComponent={DynamicHeader}
       renderItem={({ item }) => <Row icon={item} />}
       contentContainerStyle={{
         paddingHorizontal: 10,
-        backgroundColor: 'white',
       }}
     />
   );

--- a/examples/ExpoExample/app/+not-found.tsx
+++ b/examples/ExpoExample/app/+not-found.tsx
@@ -1,15 +1,21 @@
-import { Link, Stack } from "expo-router";
-import { StyleSheet, Text, View } from "react-native";
+import { Link, Stack } from 'expo-router';
+import { StyleSheet } from 'react-native';
+
+import { Text, View, useThemeColor } from '@/components/Themed';
 
 export default function NotFoundScreen() {
+  const tint = useThemeColor({}, 'tint');
+
   return (
     <>
-      <Stack.Screen options={{ title: "Oops!" }} />
+      <Stack.Screen options={{ title: 'Oops!' }} />
       <View style={styles.container}>
         <Text style={styles.title}>This screen doesn't exist.</Text>
 
         <Link href="/" style={styles.link}>
-          <Text style={styles.linkText}>Go to home screen!</Text>
+          <Text style={[styles.linkText, { color: tint }]}>
+            Go to home screen!
+          </Text>
         </Link>
       </View>
     </>
@@ -19,13 +25,13 @@ export default function NotFoundScreen() {
 const styles = StyleSheet.create({
   container: {
     flex: 1,
-    alignItems: "center",
-    justifyContent: "center",
+    alignItems: 'center',
+    justifyContent: 'center',
     padding: 20,
   },
   title: {
     fontSize: 20,
-    fontWeight: "bold",
+    fontWeight: 'bold',
   },
   link: {
     marginTop: 15,
@@ -33,6 +39,5 @@ const styles = StyleSheet.create({
   },
   linkText: {
     fontSize: 14,
-    color: "#2e78b7",
   },
 });

--- a/examples/ExpoExample/constants/Colors.ts
+++ b/examples/ExpoExample/constants/Colors.ts
@@ -5,6 +5,7 @@ export default {
   light: {
     text: '#000',
     background: '#fff',
+    screenBackground: '#eee',
     tint: tintColorLight,
     tabIconDefault: '#ccc',
     tabIconSelected: tintColorLight,
@@ -12,6 +13,7 @@ export default {
   dark: {
     text: '#fff',
     background: '#000',
+    screenBackground: '#1c1c1e',
     tint: tintColorDark,
     tabIconDefault: '#ccc',
     tabIconSelected: tintColorDark,

--- a/packages/react-native-nano-icons/android/src/main/java/com/nanoicons/NanoIconView.kt
+++ b/packages/react-native-nano-icons/android/src/main/java/com/nanoicons/NanoIconView.kt
@@ -1,10 +1,13 @@
 package com.nanoicons
 
 import android.content.Context
+import android.content.res.Configuration
 import android.graphics.Canvas
+import android.graphics.Color
 import android.graphics.Paint
 import android.graphics.Typeface
 import android.view.View
+import com.facebook.react.bridge.ColorPropConverter
 import com.facebook.react.common.assets.ReactFontManager
 
 class NanoIconView(context: Context) : View(context) {
@@ -13,6 +16,11 @@ class NanoIconView(context: Context) : View(context) {
   private val fontMetrics = Paint.FontMetrics()
   private var codepoints: IntArray = intArrayOf()
   private var colors: IntArray = intArrayOf()
+  // Unresolved layer colors: literal ARGB, plus resource paths for the entries that
+  // depend on the theme (PlatformColor). Kept so they can be re-resolved on a
+  // configuration change — the props are not re-sent for that.
+  private var literalColors: IntArray = intArrayOf()
+  private var colorPaths: Array<Array<String>?>? = null
   private var cachedFontFamily: String? = null
   private var cachedTypeface: Typeface? = null
   // Cached String objects — rebuilt only when codepoints change
@@ -54,8 +62,32 @@ class NanoIconView(context: Context) : View(context) {
     invalidate()
   }
 
-  fun setColors(values: IntArray) {
-    colors = values
+  fun setColors(literals: IntArray, paths: Array<Array<String>?>?) {
+    literalColors = literals
+    colorPaths = paths
+    resolveColors()
+    invalidate()
+  }
+
+  // Resolve theme-dependent entries against this view's current context; literal
+  // entries pass through untouched.
+  private fun resolveColors() {
+    val paths = colorPaths
+    if (paths == null) {
+      colors = literalColors
+      return
+    }
+    colors = IntArray(literalColors.size) { i ->
+      val entry = paths[i] ?: return@IntArray literalColors[i]
+      entry.firstNotNullOfOrNull { ColorPropConverter.resolveResourcePath(context, it) }
+        ?: Color.BLACK
+    }
+  }
+
+  override fun onConfigurationChanged(newConfig: Configuration) {
+    super.onConfigurationChanged(newConfig)
+    if (colorPaths == null) return
+    resolveColors()
     invalidate()
   }
 

--- a/packages/react-native-nano-icons/android/src/main/java/com/nanoicons/NanoIconViewManager.kt
+++ b/packages/react-native-nano-icons/android/src/main/java/com/nanoicons/NanoIconViewManager.kt
@@ -1,6 +1,9 @@
 package com.nanoicons
 
+import android.graphics.Color
+import com.facebook.react.bridge.ColorPropConverter
 import com.facebook.react.bridge.ReadableArray
+import com.facebook.react.bridge.ReadableType
 import com.facebook.react.module.annotations.ReactModule
 import com.facebook.react.uimanager.SimpleViewManager
 import com.facebook.react.uimanager.ThemedReactContext
@@ -46,14 +49,32 @@ class NanoIconViewManager :
     }
   }
 
+  // Plain colors arrive pre-processed as ints; PlatformColor as a map. Resource-path
+  // maps are forwarded unresolved so the view can re-resolve them when the theme
+  // changes — resolving here would discard what that needs.
   @ReactProp(name = "colors")
   override fun setColors(view: NanoIconView, value: ReadableArray?) {
     if (value != null) {
-      val arr = IntArray(value.size())
-      for (i in 0 until value.size()) {
-        arr[i] = value.getInt(i)
+      val size = value.size()
+      val literals = IntArray(size)
+      var paths: Array<Array<String>?>? = null
+      for (i in 0 until size) {
+        if (value.getType(i) == ReadableType.Map) {
+          val map = value.getMap(i)
+          val resourcePaths = map?.getArray("resource_paths")
+          if (resourcePaths != null) {
+            if (paths == null) paths = arrayOfNulls(size)
+            paths[i] =
+              Array(resourcePaths.size()) { resourcePaths.getString(it).orEmpty() }
+          } else {
+            // {space,r,g,b,a} wide-gamut form — theme-invariant, resolve once.
+            literals[i] = ColorPropConverter.getColor(map, view.context, Color.BLACK)
+          }
+        } else {
+          literals[i] = value.getInt(i)
+        }
       }
-      view.setColors(arr)
+      view.setColors(literals, paths)
     }
   }
 

--- a/packages/react-native-nano-icons/ios/NanoIconView.mm
+++ b/packages/react-native-nano-icons/ios/NanoIconView.mm
@@ -61,7 +61,9 @@ void NanoIconInvalidateFontCache(NSString *family) {
   NSString *_fontFamily;
   CGFloat _fontSize;
   std::vector<CGGlyph> _glyphs;
-  std::vector<uint32_t> _colors;
+  // Unresolved layer colors — may be trait-dependent (DynamicColorIOS, PlatformColor).
+  NSArray<UIColor *> *_layerColors;
+  // _layerColors resolved against the current trait collection.
   std::vector<CGColorRef> _cachedCGColors;
   CGFloat _fitScale;
   CGPoint _baselinePosition;
@@ -330,17 +332,17 @@ void NanoIconInvalidateFontCache(NSString *family) {
   _cachedCGColors.clear();
 }
 
-// Convert ARGB uint32 color values into cached CGColorRefs.
+// Resolve the layer colors against the current traits into cached CGColorRefs.
+// Resolving up front (rather than relying on UIKit's current trait collection at
+// draw time) keeps the CALayer inline-in-Text path correct — CoreAnimation does
+// not install a trait collection around -drawInContext:.
 - (void)_rebuildCachedColors {
   [self _releaseCachedColors];
-  _cachedCGColors.resize(_colors.size());
-  for (size_t i = 0; i < _colors.size(); i++) {
-    uint32_t ci = _colors[i];
-    _cachedCGColors[i] = CGColorCreateSRGB(
-        ((ci >> 16) & 0xFF) / 255.0,
-        ((ci >> 8)  & 0xFF) / 255.0,
-        ( ci        & 0xFF) / 255.0,
-        ((ci >> 24) & 0xFF) / 255.0);
+  UITraitCollection *traits = self.traitCollection;
+  _cachedCGColors.resize(_layerColors.count);
+  for (NSUInteger i = 0; i < _layerColors.count; i++) {
+    UIColor *resolved = [_layerColors[i] resolvedColorWithTraitCollection:traits];
+    _cachedCGColors[i] = CGColorRetain(resolved.CGColor);
   }
 }
 
@@ -389,10 +391,12 @@ void NanoIconInvalidateFontCache(NSString *family) {
 
   if (oldViewProps.colors != newViewProps.colors) {
     const auto &colors = newViewProps.colors;
-    _colors.resize(colors.size());
+    NSMutableArray<UIColor *> *layerColors = [NSMutableArray arrayWithCapacity:colors.size()];
     for (size_t i = 0; i < colors.size(); i++) {
-      _colors[i] = (uint32_t)colors[i];
+      UIColor *color = RCTUIColorFromSharedColor(colors[i]);
+      [layerColors addObject:color ?: [UIColor blackColor]];
     }
+    _layerColors = layerColors;
     [self _rebuildCachedColors];
     needsRedraw = YES;
   }
@@ -404,6 +408,25 @@ void NanoIconInvalidateFontCache(NSString *family) {
     } else {
       [self setNeedsDisplay];
     }
+  }
+}
+
+// Trait-dependent colors (DynamicColorIOS, PlatformColor) resolve to a different
+// CGColor when the interface style or contrast changes. Fabric does not re-send
+// props for that, so re-resolve and redraw here.
+- (void)traitCollectionDidChange:(UITraitCollection *)previousTraitCollection {
+  [super traitCollectionDidChange:previousTraitCollection];
+
+  if (_layerColors.count == 0) return;
+  if (![self.traitCollection hasDifferentColorAppearanceComparedToTraitCollection:previousTraitCollection]) {
+    return;
+  }
+
+  [self _rebuildCachedColors];
+  if (_isInlineInText && _drawingLayer) {
+    [_drawingLayer setNeedsDisplay];
+  } else {
+    [self setNeedsDisplay];
   }
 }
 

--- a/packages/react-native-nano-icons/src/createNanoIconsSet.native.tsx
+++ b/packages/react-native-nano-icons/src/createNanoIconsSet.native.tsx
@@ -1,5 +1,6 @@
 import { memo, useMemo } from 'react';
-import { PixelRatio, UIManager, View, processColor } from 'react-native';
+import { PixelRatio, UIManager, View } from 'react-native';
+import type { ColorValue } from 'react-native';
 import type { NanoGlyphMapInput, GlyphEntry } from './core/types';
 import type { IconComponent, IconProps } from './types';
 import { shallowEqualColor } from './utils/shallowEqualColor';
@@ -19,18 +20,6 @@ export type { IconComponent, IconProps };
 export { shallowEqualColor };
 
 const HAS_NATIVE_IMPL = UIManager.hasViewManagerConfig('NanoIconView');
-
-// Shared processColor cache — avoids redundant color parsing for repeated
-// color strings like "black", "rgba(0,0,0,0.3)" across thousands of icons
-const processedColorCache = new Map<string, number>();
-function cachedProcessColor(color: string): number {
-  let result = processedColorCache.get(color);
-  if (result === undefined) {
-    result = (processColor(color) ?? 0xff000000) as number;
-    processedColorCache.set(color, result);
-  }
-  return result;
-}
 
 export function createIconSet<GM extends NanoGlyphMapInput>(
   glyphMap: GM
@@ -64,9 +53,10 @@ export function createIconSet<GM extends NanoGlyphMapInput>(
   }
 
   // Pre-compute per-icon static data (codepoints, default colors) once at set creation
-  // Avoids layers.map() + processColor per icon mount
+  // Avoids layers.map() per icon mount, and keeps the array identity stable so
+  // React Native's prop diff skips re-running processColorArray on re-render.
   const codepointsCache = new Map<string, readonly number[]>();
-  const defaultColorsCache = new Map<string, readonly number[]>();
+  const defaultColorsCache = new Map<string, readonly ColorValue[]>();
 
   function getCodepoints(
     name: string,
@@ -83,12 +73,10 @@ export function createIconSet<GM extends NanoGlyphMapInput>(
   function getDefaultColors(
     name: string,
     layers: GlyphEntry[1]
-  ): readonly number[] {
+  ): readonly ColorValue[] {
     let colors = defaultColorsCache.get(name);
     if (!colors) {
-      colors = layers.map(([, srcColor]) =>
-        cachedProcessColor(srcColor ?? 'black')
-      );
+      colors = layers.map(([, srcColor]) => srcColor ?? 'black');
       defaultColorsCache.set(name, colors);
     }
     return colors;
@@ -119,15 +107,13 @@ export function createIconSet<GM extends NanoGlyphMapInput>(
       const nameStr = name as string;
       const codepoints = getCodepoints(nameStr, layers);
 
-      const processedColors = useMemo(() => {
+      const layerColors = useMemo(() => {
         // Fast path: no custom color — use pre-computed defaults
         if (color === undefined || color === null) {
           return getDefaultColors(nameStr, layers);
         }
         const resolveColor = createLayerColorResolver(color);
-        return layers.map(([, srcColor], i) =>
-          cachedProcessColor(resolveColor(i, srcColor) as string)
-        );
+        return layers.map(([, srcColor], i) => resolveColor(i, srcColor));
       }, [nameStr, color]);
 
       const nativeStyle = useMemo(
@@ -151,13 +137,12 @@ export function createIconSet<GM extends NanoGlyphMapInput>(
           />
         );
       }
-      console.log({ processedColors });
       return (
         <NanoIconViewNative
           ref={ref}
           fontFamily={fontFamilyBasename}
           codepoints={codepoints}
-          colors={processedColors}
+          colors={layerColors}
           fontSize={size}
           advanceWidth={adv}
           unitsPerEm={unitsPerEm}

--- a/packages/react-native-nano-icons/src/createNanoIconsSet.native.tsx
+++ b/packages/react-native-nano-icons/src/createNanoIconsSet.native.tsx
@@ -151,7 +151,7 @@ export function createIconSet<GM extends NanoGlyphMapInput>(
           />
         );
       }
-
+      console.log({ processedColors });
       return (
         <NanoIconViewNative
           ref={ref}

--- a/packages/react-native-nano-icons/src/createNanoIconsSet.shared.tsx
+++ b/packages/react-native-nano-icons/src/createNanoIconsSet.shared.tsx
@@ -125,7 +125,6 @@ export function createJSIconSet<GM extends NanoGlyphMapInput>(
       );
 
       const sizeStyle = useMemo(() => ({ fontSize: size }), [size]);
-      console.log({ color });
       return (
         <View
           ref={ref}
@@ -140,7 +139,6 @@ export function createJSIconSet<GM extends NanoGlyphMapInput>(
             ? null
             : layers.map(([codepoint, srcColor], i) => {
                 const layerColor = resolveColor(i, srcColor);
-                console.log(layerColor);
                 return (
                   <Text
                     key={i}

--- a/packages/react-native-nano-icons/src/createNanoIconsSet.shared.tsx
+++ b/packages/react-native-nano-icons/src/createNanoIconsSet.shared.tsx
@@ -125,7 +125,7 @@ export function createJSIconSet<GM extends NanoGlyphMapInput>(
       );
 
       const sizeStyle = useMemo(() => ({ fontSize: size }), [size]);
-
+      console.log({ color });
       return (
         <View
           ref={ref}
@@ -140,7 +140,7 @@ export function createJSIconSet<GM extends NanoGlyphMapInput>(
             ? null
             : layers.map(([codepoint, srcColor], i) => {
                 const layerColor = resolveColor(i, srcColor);
-
+                console.log(layerColor);
                 return (
                   <Text
                     key={i}

--- a/packages/react-native-nano-icons/src/specs/NanoIconViewNativeComponent.ts
+++ b/packages/react-native-nano-icons/src/specs/NanoIconViewNativeComponent.ts
@@ -1,11 +1,11 @@
 import { codegenNativeComponent } from 'react-native';
-import type { ViewProps } from 'react-native';
+import type { ColorValue, ViewProps } from 'react-native';
 import type { Float, Int32 } from '../const/codegenPrimitives';
 
 export interface NativeProps extends ViewProps {
   fontFamily: string;
   codepoints: ReadonlyArray<Int32>;
-  colors: ReadonlyArray<Int32>;
+  colors: ReadonlyArray<ColorValue>;
   fontSize: Float;
   advanceWidth: Int32;
   unitsPerEm: Int32;


### PR DESCRIPTION
## Description

The `color` prop says that it supports `ColorValue | ColorValue[]` but in reality it only supports strings. Passing `DynamicColorIOS` or `PlatformColor` on that prop results in a black icon (the fallback color).

This PR adds an example tab to the Expo example app with icons using `PlatformColor` or `DynamicColorIOS`. It also refactors `NanoIconViewNativeComponent` so the `colors` prop has type `ReadonlyArray<ColorValue>` instead of `ReadonlyArray<Int32>`

## Test plan

1. Run the expo example app
2. Open the new tab "Colors"
3. Toggle system appearance and see that the icon colors changes
